### PR TITLE
Added ImGui panel to mqsettings, changes, and fixes applied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+7/11/2024
+--
+Added
+- MQ Settings panel (/mqsettings -> plugin -> AutoSize)
+- AutoSize TLO (check wiki for details)
+- Introduced Synchronization ability - only available in the UI
+- Enhanced options to accept instruction such as on and off, not just be a toggle. This was done to enable keeping toons in sync by setting values instead of randomly toggling.
+
+Updated / Fixed
+- Zonewide now uses 1000 range
+- /autosize range # now works
+- Reduced organic growth of code and made all toggle options use the ToggleOption function
+- Fixed and altered how "Everything" works. Now it will enable the options, which work as intended.
+
+Deprecated
+- OptZone since it never worked as expected, replaced with Range of 1000 which is about the same as the EQ visible max clipping plane
+- ResizeAll configuration, while Everything is still able to be enabled
+- DefaultSize configuration and command (/autosize size), while Everything is still able to be enabled
+- SizeDefault since having a default setting to resize something to, which wasn't opted in for resizing, doesn't actually make any sense. Outputs have persisted to ensure no script that scrapes the line breaks.
+- SizeTarget (and /autosize target) since it would only resize for one frame if the type was managed by an Option for resizing
+- OptByRange and SizeByRange, since the plugin now only uses range to resize
+
+
+Under the hood
+- Changed the majority of floats to integer as there was no reason for using all the floats
+- Updated pCharSpawn to pLocalPlayer references

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -80,6 +80,175 @@ public:
 };
 COurSizes AS_Config;
 
+// exposed TLO variables
+class MQ2AutoSizeType* pAutoSizeType = 0;
+class MQ2AutoSizeType : public MQ2Type
+{
+public:
+	enum AutoSizeMembers
+	{
+		Active,
+		AutoSave,
+		ResizePC,
+		ResizeNPC,
+		ResizePets,
+		ResizeMercs,
+		ResizeAll,
+		ResizeMounts,
+		ResizeCorpse,
+		ResizeSelf,
+		SizeByRange,
+		Range,
+		SizeDefault,
+		SizePC,
+		SizeNPC,
+		SizePets,
+		SizeMercs,
+		SizeTarget,
+		SizeMounts,
+		SizeCorpse,
+		SizeSelf
+	};
+
+	MQ2AutoSizeType() :MQ2Type("AutoSize")
+	{
+		TypeMember(Active);
+		TypeMember(AutoSave);
+		TypeMember(ResizePC);
+		TypeMember(ResizeNPC);
+		TypeMember(ResizePets);
+		TypeMember(ResizeMercs);
+		TypeMember(ResizeAll);
+		TypeMember(ResizeMounts);
+		TypeMember(ResizeCorpse);
+		TypeMember(ResizeSelf);
+		TypeMember(SizeByRange);
+		TypeMember(Range);
+		TypeMember(SizeDefault);
+		TypeMember(SizePC);
+		TypeMember(SizeNPC);
+		TypeMember(SizePets);
+		TypeMember(SizeMercs);
+		TypeMember(SizeTarget);
+		TypeMember(SizeMounts);
+		TypeMember(SizeCorpse);
+		TypeMember(SizeSelf);
+	}
+
+	~MQ2AutoSizeType()
+	{
+	}
+
+	bool GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest)
+	{
+
+		MQTypeMember* pMember = MQ2AutoSizeType::FindMember(Member);
+		if (!pMember)
+			return false;
+
+		switch ((AutoSizeMembers)pMember->ID)
+		{
+		case Active:
+			Dest.Int = AS_Config.OptPC || AS_Config.OptNPC || AS_Config.OptPet || AS_Config.OptMerc || AS_Config.OptMount || AS_Config.OptCorpse || AS_Config.OptSelf;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case AutoSave:
+			Dest.Int = AS_Config.OptAutoSave;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizePC:
+			Dest.Int = AS_Config.OptPC;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeNPC:
+			Dest.Int = AS_Config.OptNPC;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizePets:
+			Dest.Int = AS_Config.OptPet;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeMercs:
+			Dest.Int = AS_Config.OptMerc;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeAll:
+			Dest.Int = AS_Config.OptEverything;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeMounts:
+			Dest.Int = AS_Config.OptMount;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeCorpse:
+			Dest.Int = AS_Config.OptCorpse;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeSelf:
+			Dest.Int = AS_Config.OptSelf;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case SizeByRange:
+			Dest.Int = AS_Config.OptByRange;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case Range:
+			Dest.Int = AS_Config.ResizeRange;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeDefault:
+			Dest.Int = AS_Config.SizeDefault;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizePC:
+			Dest.Int = AS_Config.SizePC;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeNPC:
+			Dest.Int = AS_Config.SizeNPC;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizePets:
+			Dest.Int = AS_Config.SizePet;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeMercs:
+			Dest.Int = AS_Config.SizeMerc;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeTarget:
+			Dest.Int = AS_Config.SizeTarget;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeMounts:
+			Dest.Int = AS_Config.SizeMount;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeCorpse:
+			Dest.Int = AS_Config.SizeCorpse;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeSelf:
+			Dest.Int = AS_Config.SizeSelf;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		}
+		return false;
+	}
+
+	bool ToString(MQVarPtr VarPtr, char* Destination)
+	{
+		return true;
+	}
+};
+
+bool dataAutoSize(const char* szIndex, MQTypeVar& ret)
+{
+	ret.DWord = 1;
+	ret.Type = pAutoSizeType;
+	return true;
+}
+
 // class to access the ChangeHeight function
 class PlayerZoneClient_Hook
 {
@@ -718,7 +887,8 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 PLUGIN_API void InitializePlugin()
 {
 	EzDetour(PlayerZoneClient__ChangeHeight, &PlayerZoneClient_Hook::ChangeHeight_Detour, &PlayerZoneClient_Hook::ChangeHeight_Trampoline);
-
+	pAutoSizeType = new MQ2AutoSizeType;
+	AddMQ2Data("AutoSize", dataAutoSize);
 	AddCommand("/autosize", AutoSizeCmd);
 	AddSettingsPanel("plugins/AutoSize", DrawAutoSize_MQSettingsPanel);
 	LoadINI();
@@ -731,7 +901,8 @@ PLUGIN_API void ShutdownPlugin()
 	RemoveCommand("/autosize");
 	SpawnListResize(true);
 	SaveINI();
-
+	RemoveMQ2Data("AutoSize");
+	delete pAutoSizeType;
 }
 
 void DrawAutoSize_MQSettingsPanel()

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -37,6 +37,7 @@ void DoGroupCommand(std::string_view command, bool includeSelf);
 void ChooseInstructionPlugin();
 void emulate(std::string type);
 void DrawAutoSize_MQSettingsPanel();
+void SendGroupCommand(std::string who);
 int optZonewide = 2; // defaults to selecting Range
 int selectedComms = 0; // defaults to none, OnPulse will query for updates
 int previousRangeDistance = 0;
@@ -585,7 +586,19 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 		return;
 	}
 	else if (ci_equals(szCurArg, "autosave")) {
-		ToggleOption("Autosave", &AS_Config.OptAutoSave);
+		if (ci_equals(szNumber, "on")) {
+			if (!AS_Config.OptAutoSave) {
+				ToggleOption("Autosave", &AS_Config.OptAutoSave);
+			}
+		}
+		else if (ci_equals(szNumber, "off")) {
+			if (AS_Config.OptAutoSave) {
+				ToggleOption("Autosave", &AS_Config.OptAutoSave);
+			}
+		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			ToggleOption("Autosave", &AS_Config.OptAutoSave);
+		}
 		return;
 	}
 	else if (ci_equals(szCurArg, "range")) {
@@ -617,14 +630,34 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 		SetSizeConfig("Self", iNewSize, &AS_Config.SizeSelf);
 	}
 	else if (ci_equals(szCurArg, "pc")) {
-		if (!ToggleOption("PC", &AS_Config.OptPC)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptPC) {
+			ToggleOption("PC", &AS_Config.OptPC);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptPC) {
+			ToggleOption("PC", &AS_Config.OptPC);
 			ResetAllByType(PC);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("PC", &AS_Config.OptPC)) {
+				ResetAllByType(PC);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "npc")) {
-		if (!ToggleOption("NPC", &AS_Config.OptNPC)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptNPC) {
+			ToggleOption("NPC", &AS_Config.OptNPC);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptNPC) {
+			ToggleOption("NPC", &AS_Config.OptNPC);
 			ResetAllByType(NPC);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("PC", &AS_Config.OptNPC)) {
+				ResetAllByType(NPC);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "everything")) {
 		// a different approach for a better user experience
@@ -651,38 +684,84 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 		}		
 	}
 	else if (ci_equals(szCurArg, "pets")) {
-		if (!ToggleOption("Pets", &AS_Config.OptPet)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptPet) {
+			ToggleOption("Pets", &AS_Config.OptPet);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptPet) {
+			ToggleOption("Pets", &AS_Config.OptPet);
 			ResetAllByType(PET);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Pets", &AS_Config.OptPet)) {
+				ResetAllByType(PET);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "mercs")) {
-		if (!ToggleOption("Mercs", &AS_Config.OptMerc)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptMerc) {
+			ToggleOption("Mercs", &AS_Config.OptMerc);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptMerc) {
+			ToggleOption("Mercs", &AS_Config.OptMerc);
 			ResetAllByType(MERCENARY);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Mercs", &AS_Config.OptMerc)) {
+				ResetAllByType(MERCENARY);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "mounts")) {
-		if (!ToggleOption("Mounts", &AS_Config.OptMount)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptMount) {
+			ToggleOption("Mounts", &AS_Config.OptMount);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptMount) {
+			ToggleOption("Mounts", &AS_Config.OptMount);
 			ResetAllByType(MOUNT);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Mounts", &AS_Config.OptMount)) {
+				ResetAllByType(MOUNT);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "corpse")) {
-		if (!ToggleOption("Corpses", &AS_Config.OptCorpse)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptCorpse) {
+			ToggleOption("Corpses", &AS_Config.OptCorpse);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptCorpse) {
+			ToggleOption("Corpses", &AS_Config.OptCorpse);
 			ResetAllByType(CORPSE);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Corpses", &AS_Config.OptCorpse)) {
+				ResetAllByType(CORPSE);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "target")) {
-		// deprecated because when you use this while having features enabled this feature didn't actually work
+		// deprecated because when you use this while having features enabled this feature didn't actually work.
+		// if you don't have anything resizing, why would you want to resize just the target?
 		WriteChatf("\ay%s\aw:: This feature (\ay%s\ax) has been deprecated. Check /mqsetting -> plugins -> AutoSize.", MODULE_NAME, szCurArg);
 	}
 	else if (ci_equals(szCurArg, "self")) {
-		if (!ToggleOption("Self", &AS_Config.OptSelf)) {
-			if (((PSPAWNINFO)pLocalPlayer)->Mount) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptSelf) {
+			ToggleOption("Self", &AS_Config.OptSelf);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptSelf) {
+			ToggleOption("Self", &AS_Config.OptSelf);
+			ChangeSize((PSPAWNINFO)pLocalPlayer, ZERO_SIZE);
+		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Self", &AS_Config.OptSelf)) {
 				ChangeSize((PSPAWNINFO)pLocalPlayer, ZERO_SIZE);
 			}
-			else {
-				ChangeSize((PSPAWNINFO)pCharSpawn, ZERO_SIZE);
-			}
 		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "help")) {
 		OutputHelp();
@@ -847,7 +926,6 @@ void DrawAutoSize_MQSettingsPanel() {
 				}
 			}
 
-			ImGui::NewLine();
 			ImGui::SeparatorText("Synchronize clients");
 			if (ImGui::RadioButton("None", &selectedComms, static_cast<int>(CommunicationMode::None))) {
 				selectedComms = static_cast<int>(CommunicationMode::None);
@@ -876,27 +954,27 @@ void DrawAutoSize_MQSettingsPanel() {
 			// if dannet
 			if (selectedComms == static_cast<int>(CommunicationMode::DanNet) && loaded_dannet) {
 				if (ImGui::Button("All")) {
-					DoCommandf("a");
+					SendGroupCommand("all");
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("Zone")) {
-					DoCommandf("a");
+					SendGroupCommand("zone");
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("Raid")) {
-					DoCommandf("a");
+					SendGroupCommand("raid");
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("Group")) {
-					DoCommandf("a");
+					SendGroupCommand("group");
 				}
 			} else if (selectedComms == static_cast<int>(CommunicationMode::EQBC) && loaded_eqbc) {
 				if (ImGui::Button("All")) {
-					DoCommandf("a");
+					SendGroupCommand("all");
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("Group")) {
-					DoCommandf("a");
+					SendGroupCommand("group");
 				}
 			}
 
@@ -1003,14 +1081,27 @@ void DrawAutoSize_MQSettingsPanel() {
 	}
 }
 
-void DoGroupCommand(std::string who, std::string_view command) {
-	if (selectedComms == static_cast<int>(CommunicationMode::EQBC)) {
+// send instruction to select few
+// -> dannet: all, zone, raid, group
+// -> eqbc: all, group
+void SendGroupCommand(std::string who) {
+	if (selectedComms == static_cast<int>(CommunicationMode::None)) {
 		WriteChatf("MQ2AutoSize: Cannot execute group command, no group plugin configured.");
 		return;
 	}
 
 	std::string groupCommand;
 	groupCommand = "/squelch ";
+	std::string_view command;
+
+	// if auto save is enabled
+	if (AS_Config.OptAutoSave) {
+		command = "/autosize load";
+	}
+	else {
+		// if auto save is not enabled, save locally then load elsewhere
+		command = "/multiline ; /autosize ";
+	}
 
 	if (selectedComms == static_cast<int>(CommunicationMode::DanNet)) {
 		if (who == "zone")
@@ -1020,7 +1111,7 @@ void DoGroupCommand(std::string who, std::string_view command) {
 		else if (who == "group")
 			groupCommand += fmt::format("/dgga {}", command);
 		else if (who == "all")
-			groupCommand += fmt::format("/dgae all {}", command);
+			groupCommand += fmt::format("/dge {}", command); // everyone but self since we already have it locally
 	}
 	else if (selectedComms == static_cast<int>(CommunicationMode::EQBC)) {
 		if (who == "group")

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -530,7 +530,7 @@ void OutputStatus() {
 		AS_Config.OptMount ? szOn : szOff,
 		AS_Config.OptCorpse ? szOn : szOff,
 		AS_Config.OptSelf ? szOn : szOff,
-		szOff // // no longer available but left to ensure that no random script that reads this, breaks.
+		szOff // no longer available but left to ensure that no random script that reads this, breaks.
 	);
 	WriteChatf("Sizes: PC(\ag%d\ax) NPC(\ag%d\ax) Pets(\ag%d\ax) Mercs(\ag%d\ax) Mounts(\ag%d\ax) Corpses(\ag%d\ax) Target(\ag%d\ax) Self(\ag%d\ax) Everything(\ag%d\ax)",
 		AS_Config.SizePC,

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1,4 +1,4 @@
-// MQ2AutoSize.cpp : Resize spawns by distance or whole zone (client only)
+// MQ2AutoSize.cpp : Resize spawns by distance (client only)
 
 #include <mq/Plugin.h>
 

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -38,6 +38,8 @@ void emulate(std::string type);
 void DrawAutoSize_MQSettingsPanel();
 void SendGroupCommand(std::string who);
 int RoundToNearestTen(int value);
+static bool isInGroup();
+static bool isInRaid();
 int optZonewide = 2; // defaults to selecting Range
 int selectedComms = 0; // defaults to none, OnPulse will query for updates
 int previousRangeDistance = 0;
@@ -1046,7 +1048,7 @@ void DrawAutoSize_MQSettingsPanel() {
 			}
 			ImGui::EndDisabled();
 
-			// if dannet
+			// dannet
 			if (selectedComms == static_cast<int>(CommunicationMode::DanNet) && loaded_dannet) {
 				if (ImGui::Button("All")) {
 					SendGroupCommand("all");
@@ -1056,21 +1058,28 @@ void DrawAutoSize_MQSettingsPanel() {
 					SendGroupCommand("zone");
 				}
 				ImGui::SameLine();
+				ImGui::BeginDisabled(!isInRaid());
 				if (ImGui::Button("Raid")) {
 					SendGroupCommand("raid");
 				}
+				ImGui::EndDisabled();
 				ImGui::SameLine();
+				ImGui::BeginDisabled(!isInGroup());
 				if (ImGui::Button("Group")) {
 					SendGroupCommand("group");
 				}
+				ImGui::EndDisabled();
 			} else if (selectedComms == static_cast<int>(CommunicationMode::EQBC) && loaded_eqbc) {
+				// eqbc
 				if (ImGui::Button("All")) {
 					SendGroupCommand("all");
 				}
 				ImGui::SameLine();
+				ImGui::BeginDisabled(!isInGroup());
 				if (ImGui::Button("Group")) {
 					SendGroupCommand("group");
 				}
+				ImGui::EndDisabled();
 			}
 
 			ImGui::EndTabItem();
@@ -1258,8 +1267,8 @@ void SendGroupCommand(std::string who) {
 	}
 
 	if (!groupCommand.empty())
-		//DoCommandf(groupCommand.c_str());
-		WriteChatf("DEBUG: command: %s", groupCommand.c_str());
+		DoCommandf(groupCommand.c_str());
+		//WriteChatf("DEBUG: command: %s", groupCommand.c_str());
 }
 
 /**
@@ -1366,4 +1375,22 @@ int RoundToNearestTen(int value) {
 	else {
 		return roundedValue;
 	}
+}
+
+static bool isInGroup() {
+	if (pLocalPC) {
+		if (pLocalPC->Group) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool isInRaid() {
+	if (pRaid) {
+		if (pRaid->RaidMemberCount) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -61,13 +61,12 @@ class COurSizes {
 public:
 	COurSizes() {
 		OptPC = true;
-		OptNPC = OptPet = OptMerc = OptMount = OptCorpse = OptSelf = OptEverything = OptAutoSave = false;
+		OptNPC = OptPet = OptMerc = OptMount = OptCorpse = OptSelf = OptAutoSave = false;
 		ResizeRange = 50;
 		SizeDefault = SizePC = SizeNPC = SizePet = SizeMerc = SizeMount = SizeCorpse = SizeSelf = 1;
 	};
 
 	bool OptAutoSave;
-	bool OptEverything;
 	bool OptPC;
 	bool OptNPC;
 	bool OptPet;
@@ -392,11 +391,6 @@ void SizePasser(PSPAWNINFO pSpawn, bool bReset) {
 		default:
 			break;
 	}
-
-	// no longer used since the Everything feature was changed to work
-	//if (AS_Config.OptEverything && pSpawn->SpawnID != pLPlayer->SpawnID) {
-	//	ChangeSize(pSpawn, bReset ? ZERO_SIZE : AS_Config.SizeDefault);
-	//}
 }
 
 void ResetAllByType(eSpawnType OurType) {
@@ -513,8 +507,8 @@ void OutputStatus() {
 		AS_Config.OptMount ? szOn : szOff,
 		AS_Config.OptCorpse ? szOn : szOff,
 		AS_Config.OptSelf ? szOn : szOff,
-		//AS_Config.OptEverything ? szOn : szOff
-		szOff);
+		szOff // // no longer available but left to ensure that no random script that reads this, breaks.
+	);
 	WriteChatf("Sizes: PC(\ag%d\ax) NPC(\ag%d\ax) Pets(\ag%d\ax) Mercs(\ag%d\ax) Mounts(\ag%d\ax) Corpses(\ag%d\ax) Target(\ag%d\ax) Self(\ag%d\ax) Everything(\ag%d\ax)",
 		AS_Config.SizePC,
 		AS_Config.SizeNPC,
@@ -524,7 +518,8 @@ void OutputStatus() {
 		AS_Config.SizeCorpse,
 		0, // no longer available but left to ensure that no random script that reads this, breaks.
 		AS_Config.SizeSelf,
-		AS_Config.SizeDefault);
+		0 // no longer available but left to ensure that no random script that reads this, breaks.
+	);
 }
 
 bool ToggleOption(const char* pszToggleOutput, bool* pbOption) {

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -862,7 +862,7 @@ void DrawAutoSize_MQSettingsPanel() {
 					emulate("range");
 				}
 				ImGui::TableNextColumn();
-				ImGui::BeginDisabled(AS_Config.ResizeRange == FAR_CLIP_PLANE);
+				ImGui::BeginDisabled(optZonewide == static_cast<int>(ResizeMode::Zonewide));
 				ImGui::PushItemWidth(50.0f);
 				if (ImGui::SliderInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 10, 250, "%d", ImGuiSliderFlags_NoInput|ImGuiSliderFlags_AlwaysClamp)) {
 					AS_Config.ResizeRange = RoundToNearestTen(AS_Config.ResizeRange);

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1239,6 +1239,7 @@ void SendGroupCommand(std::string who) {
 		instruction += fmt::format("/autosize self {}; /autosize sizeself {}; ", AS_Config.OptSelf ? "on" : "off", AS_Config.SizeSelf);
 	}
 
+	// instructions are sent to others, since we have the configuration already
 	if (selectedComms == static_cast<int>(CommunicationMode::DanNet)) {
 		if (who == "zone")
 			groupCommand += fmt::format("/dgze {}", instruction);
@@ -1247,13 +1248,13 @@ void SendGroupCommand(std::string who) {
 		else if (who == "group")
 			groupCommand += fmt::format("/dgge {}", instruction);
 		else if (who == "all")
-			groupCommand += fmt::format("/dge {}", instruction); // everyone but self since we already have it locally
+			groupCommand += fmt::format("/dge {}", instruction);
 	}
 	else if (selectedComms == static_cast<int>(CommunicationMode::EQBC)) {
 		if (who == "group")
-			groupCommand += fmt::format("/bcga /{}", instruction);
+			groupCommand += fmt::format("/bcg /{}", instruction);
 		else if (who == "all")
-			groupCommand += fmt::format("/bcaa /{}", instruction);
+			groupCommand += fmt::format("/bca /{}", instruction);
 	}
 
 	if (!groupCommand.empty())
@@ -1348,7 +1349,7 @@ void emulate(std::string type) {
 }
 
 int RoundToNearestTen(int value) {
-	// Ensure the value is within the accepted range
+	// clamp lower value
 	if (value < 10) {
 		return 10;
 	}
@@ -1356,10 +1357,9 @@ int RoundToNearestTen(int value) {
 		return 250;
 	}
 
-	// Calculate the rounded value
 	int roundedValue = (value + 9) / 10 * 10;
 
-	// Ensure the rounded value is within the accepted range
+	// clamp upper value post rounding
 	if (roundedValue > MAX_SIZE) {
 		return 250;
 	}

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -911,6 +911,136 @@ void DrawAutoSize_MQSettingsPanel()
 	ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_None;
 	if (ImGui::BeginTabBar("AutoSizeTabBar", tab_bar_flags))
 	{
+				
+		if (ImGui::BeginTabItem("Options"))
+		{
+			ImGui::SeparatorText("General");
+
+			if (ImGui::Checkbox("Enable auto saving of configuration", &AS_Config.OptAutoSave)) {
+				AS_Config.OptAutoSave = !AS_Config.OptAutoSave;
+				DoCommandf("/autosize autosave");
+			}
+			if (ImGui::RadioButton("Zonewide (max clipping plane)", &optZonewide, 0)) {
+				optZonewide = 0; // this is not a boolean, this indicates which radio button to enable
+				previousRangeDistance = AS_Config.ResizeRange;
+				AS_Config.ResizeRange = 1000;
+				AS_Config.OptByRange = true; // TODO: enable by default, comment out any/all zonewide related things
+				SpawnListResize(false);
+			}
+			if (ImGui::BeginTable("OptionsResizeRangeTable", 2, ImGuiTableFlags_RowBg)) {
+				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 20.0f);
+				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+				ImGui::TableNextColumn();
+				if (ImGui::RadioButton("", &optZonewide, 1)) {
+					optZonewide = 1; // this is not a boolean, this indicates which radio button to enable
+					AS_Config.ResizeRange = previousRangeDistance;
+					AS_Config.OptByRange = true;
+					SpawnListResize(false);
+				}
+				ImGui::TableNextColumn();
+				ImGui::BeginDisabled(AS_Config.ResizeRange == 1000);
+				ImGui::PushItemWidth(50.0f);
+				ImGui::DragInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::EndTable();
+			}
+			ImGui::NewLine();
+			if (ImGui::Button("Display status output")) {
+				DoCommandf("/autosize status");
+			}
+			ImGui::SeparatorText("Toggles");
+			if (ImGui::BeginTable("OptionsResizeSelfTable", 2, ImGuiTableFlags_RowBg)) {
+				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 20.0f);
+				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptSelf", &AS_Config.OptSelf)) {
+					AS_Config.OptSelf = !AS_Config.OptSelf;
+					DoCommandf("/autosize self");
+				}
+				ImGui::TableNextColumn();
+				ImGui::SetNextItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptSelf);
+				ImGui::DragInt("Resize: Self##inputSS", &AS_Config.SizeSelf, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptPC", &AS_Config.OptPC)) {
+					AS_Config.OptPC = !AS_Config.OptPC;
+					DoCommandf("/autosize pc");
+				}
+				ImGui::TableNextColumn();
+				ImGui::SetNextItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptPC);
+				ImGui::DragInt("Resize: Other player(s) (incluldes those mounted)##inputOP", &AS_Config.SizePC, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptPet", &AS_Config.OptPet)) {
+					AS_Config.OptPet = !AS_Config.OptPet;
+					DoCommandf("/autosize pets");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptPet);
+				ImGui::DragInt("Resize: Pets##inputPS", &AS_Config.SizePet, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptMerc", &AS_Config.OptMerc)) {
+					AS_Config.OptMerc = !AS_Config.OptMerc;
+					DoCommandf("/autosize mercs");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptMerc);
+				ImGui::DragInt("Resize: Mercs##inputMercSize", &AS_Config.SizeMerc, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptMount", &AS_Config.OptMount)) {
+					AS_Config.OptMount = !AS_Config.OptMount;
+					DoCommandf("/autosize mounts");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptMount);
+				ImGui::DragInt("Resize: Mounts and the Player(s) on them##inputMountSize", &AS_Config.SizeMount, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptCorpse", &AS_Config.OptCorpse)) {
+					AS_Config.OptCorpse = !AS_Config.OptCorpse;
+					DoCommandf("/autosize corpse");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptCorpse);
+				ImGui::DragInt("Resize: Corpse(s)##inputCS", &AS_Config.SizeCorpse, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptNPC", &AS_Config.OptNPC)) {
+					AS_Config.OptNPC = !AS_Config.OptNPC;
+					DoCommandf("/autosize npc");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptNPC);
+				ImGui::DragInt("Resize: NPC(s)##inputNS", &AS_Config.SizeNPC, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::EndTable();
+			}
+			
+			// display the button if any option is not enabled
+			if (!AS_Config.OptCorpse || !AS_Config.OptMerc || !AS_Config.OptMount || !AS_Config.OptNPC || !AS_Config.OptPC || !AS_Config.OptPet || !AS_Config.OptSelf) {
+				ImGui::NewLine();
+				if (ImGui::Button("Resize Everything")) {
+					DoCommandf("/autosize everything");
+				}
+		}
+			ImGui::EndTabItem();
+		}
+				
 		if (ImGui::BeginTabItem("Commands"))
 		{
 			ImGui::SeparatorText("Toggles");
@@ -947,8 +1077,8 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextRow();
 				ImGui::TableNextColumn(); ImGui::Text("/autosize everything");
 				ImGui::TableNextColumn(); ImGui::Text("Toggles AutoSize all spawn types");
-			ImGui::EndTable();
-			ImGui::Unindent();
+				ImGui::EndTable();
+				ImGui::Unindent();
 			}
 
 			ImGui::SeparatorText("Size configuration (valid: 1 to 250)");
@@ -985,7 +1115,7 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextRow();
 				ImGui::TableNextColumn(); ImGui::Text("/autosize sizeself #");
 				ImGui::TableNextColumn(); ImGui::Text("Sets size for your character");
-			ImGui::EndTable();
+				ImGui::EndTable();
 			}
 			ImGui::Unindent();
 
@@ -1011,107 +1141,10 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextRow();
 				ImGui::TableNextColumn(); ImGui::Text("/autosize autosave");
 				ImGui::TableNextColumn(); ImGui::Text("Automatically save settings to INI file when an option is toggled or size is set");
-			ImGui::EndTable();
+				ImGui::EndTable();
 			}
 			ImGui::Unindent();
 
-		ImGui::EndTabItem();
-		}
-		
-		if (ImGui::BeginTabItem("Options"))
-		{
-			ImGui::SeparatorText("General");
-			if (ImGui::RadioButton("Zonewide (really max clipping plane)", &optZonewide, 0)) {
-				optZonewide = 0; // this is not a boolean, this indicates which radio button to enable
-				previousRangeDistance = AS_Config.ResizeRange;
-				AS_Config.ResizeRange = 1000;
-				AS_Config.OptByRange = true; // TODO: enable by default, comment out any/all zonewide related things
-				SpawnListResize(false);
-			}
-			if (ImGui::RadioButton("Range distance (recommended setting)", &optZonewide, 1)) {
-				optZonewide = 1; // this is not a boolean, this indicates which radio button to enable
-				AS_Config.ResizeRange = previousRangeDistance;
-				AS_Config.OptByRange = true;
-				SpawnListResize(false);
-			}
-			if (ImGui::Checkbox("Enable auto saving of configuration", &AS_Config.OptAutoSave)) {
-				AS_Config.OptAutoSave = !AS_Config.OptAutoSave;
-				DoCommandf("/autosize autosave");
-			}
-			ImGui::NewLine();
-			if (ImGui::Button("Display status output")) {
-				DoCommandf("/autosize status");
-			}
-
-			ImGui::SeparatorText("Toggles");
-			if (ImGui::Checkbox("Resize: Yourself", &AS_Config.OptSelf)) {
-				AS_Config.OptSelf = !AS_Config.OptSelf;
-				DoCommandf("/autosize self");
-			}
-			if (ImGui::Checkbox("Resize: Other players (incluldes those mounted)", &AS_Config.OptPC)) {
-				AS_Config.OptPC = !AS_Config.OptPC;
-				DoCommandf("/autosize pc");
-			}
-			if (ImGui::Checkbox("Resize: Pets", &AS_Config.OptPet)) {
-				AS_Config.OptPet = !AS_Config.OptPet;
-				DoCommandf("/autosize pets");
-			}
-			if (ImGui::Checkbox("Resize: Mercs", &AS_Config.OptMerc)) {
-				AS_Config.OptMerc = !AS_Config.OptMerc;
-				DoCommandf("/autosize mercs");
-			}
-			if (ImGui::Checkbox("Resize: Mounts and the Player(s) on them", &AS_Config.OptMount)) {
-				AS_Config.OptMount = !AS_Config.OptMount;
-				DoCommandf("/autosize mounts");
-			}
-			if (ImGui::Checkbox("Resize: Corpse(s)", &AS_Config.OptCorpse)) {
-				AS_Config.OptCorpse = !AS_Config.OptCorpse;
-				DoCommandf("/autosize corpse");
-			}
-
-			if (ImGui::Checkbox("Resize: NPC(s)", &AS_Config.OptNPC)) {
-				AS_Config.OptNPC = !AS_Config.OptNPC;
-				DoCommandf("/autosize npc");
-			}
-			
-			// display the button if any option is not enabled
-			if (!AS_Config.OptCorpse || !AS_Config.OptMerc || !AS_Config.OptMount || !AS_Config.OptNPC || !AS_Config.OptPC || !AS_Config.OptPet || !AS_Config.OptSelf) {
-				ImGui::NewLine();
-				if (ImGui::Button("Resize Everything")) {
-					DoCommandf("/autosize everything");
-				}
-		}
-			ImGui::EndTabItem();
-		}
-		
-		if (ImGui::BeginTabItem("Settings"))
-		{
-			// included in case code review asks for it to be
-			// provided instead of being a hidden value where
-			// no one is aware of how it works
-			/*
-			ImGui::BeginDisabled(true);
-			ImGui::InputInt("Zonewide##input", &FAR_CLIP_PLANE, 10, 1000);
-			ImGui::EndDisabled();
-			*/
-			ImGui::BeginDisabled(AS_Config.ResizeRange == 1000);
-			ImGui::DragInt("Range distance##inputRD", &AS_Config.ResizeRange, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::EndDisabled();
-			ImGui::DragInt("Self size##inputSS",		&AS_Config.SizeSelf,	1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Other player size##inputSS",&AS_Config.SizePC,		1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Pet size##inputPS",			&AS_Config.SizePet,		1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Merc size##inputMercSize",	&AS_Config.SizeMerc,	1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Mount size##inputMountSize",&AS_Config.SizeMount,	1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Corpse size##inputCS",		&AS_Config.SizeCorpse,	1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Everything size##inputES",	&AS_Config.SizeDefault, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("NPC size##inputNS",			&AS_Config.SizeNPC,		1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			// using SizeTarget will produce a bad experience
-			// while having other options enabled
-			/*
-			if (ImGui::DragInt("Target size##inputTS", &AS_Config.SizeTarget, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp)) {
-				DoCommandf("/squelch /autosize target");
-			}
-			*/
 			ImGui::EndTabItem();
 		}
 		ImGui::EndTabBar();

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1268,7 +1268,6 @@ void SendGroupCommand(std::string who) {
 
 	if (!groupCommand.empty())
 		DoCommandf(groupCommand.c_str());
-		//WriteChatf("DEBUG: command: %s", groupCommand.c_str());
 }
 
 /**

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1204,7 +1204,14 @@ void SendGroupCommand(std::string who) {
 
 	// if auto save is enabled
 	if (AS_Config.OptAutoSave) {
-		instruction = "/autosize load";
+		// check if zonewide is enabled and send instruction
+		if (AS_Config.ResizeRange == FAR_CLIP_PLANE) {
+			instruction += "/multiline ; /autosize load; /autosize on";
+		}
+		else {
+			// just send instruction to load configuration
+			instruction = "/autosize load";
+		}
 	}
 	else {
 		// if auto save is not enabled, we have to go through every setting

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -880,7 +880,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				if (ImGui::SliderInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 10, 250, "%d", ImGuiSliderFlags_NoInput|ImGuiSliderFlags_AlwaysClamp)) {
 					AS_Config.ResizeRange = RoundToNearestTen(AS_Config.ResizeRange);
-					SaveINI("ResizeRange", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("ResizeRange", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::EndTable();
@@ -903,7 +905,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptSelf);
 				if (ImGui::SliderInt("Resize: Self##inputSS", &AS_Config.SizeSelf, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeSelf", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeSelf", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -917,7 +921,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptPC);
 				if (ImGui::SliderInt("Resize: Other player(s) (incluldes those mounted)##inputOP", &AS_Config.SizePC, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizePC", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizePC", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -931,7 +937,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptPet);
 				if (ImGui::SliderInt("Resize: Pets##inputPS", &AS_Config.SizePet, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizePet", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizePet", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -945,7 +953,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptMerc);
 				if (ImGui::SliderInt("Resize: Mercs##inputMercSize", &AS_Config.SizeMerc, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeMerc", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeMerc", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -959,7 +969,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptMount);
 				if (ImGui::SliderInt("Resize: Mounts and the Player(s) on them##inputMountSize", &AS_Config.SizeMount, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeMount", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeMount", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -973,7 +985,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptCorpse);
 				if (ImGui::SliderInt("Resize: Corpse(s)##inputCS", &AS_Config.SizeCorpse, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeCorpse", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeCorpse", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -987,7 +1001,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptNPC);
 				if (ImGui::SliderInt("Resize: NPC(s)##inputNS", &AS_Config.SizeNPC, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeNPC", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeNPC", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::EndTable();

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -343,7 +343,6 @@ void SaveINI(const std::string& param = "", const bool squelch = 0) {
 	if (!squelch) {
 		WriteChatf("\ay%s\aw:: Configuration file saved.", MODULE_NAME);
 	}
-
 }
 
 void ChangeSize(PlayerClient* pChangeSpawn, float fNewSize) {
@@ -1063,7 +1062,6 @@ void DrawAutoSize_MQSettingsPanel() {
 				}
 				ImGui::EndDisabled();
 			}
-
 			ImGui::EndTabItem();
 		}
 				

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -700,7 +700,7 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 			ResetAllByType(NPC);
 		}
 		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
-			if (!ToggleOption("PC", &AS_Config.OptNPC)) {
+			if (!ToggleOption("NPC", &AS_Config.OptNPC)) {
 				ResetAllByType(NPC);
 			}
 		}
@@ -844,7 +844,9 @@ PLUGIN_API void ShutdownPlugin() {
 	RemoveSettingsPanel("plugins/AutoSize");
 	RemoveCommand("/autosize");
 	SpawnListResize(true);
-	SaveINI();
+	if (AS_Config.OptAutoSave) {
+		SaveINI();
+	}
 	RemoveMQ2Data("AutoSize");
 	delete pAutoSizeType;
 }
@@ -1262,7 +1264,8 @@ void SendGroupCommand(std::string who) {
 	}
 
 	if (!groupCommand.empty())
-		DoCommandf(groupCommand.c_str());
+		//DoCommandf(groupCommand.c_str());
+		WriteChatf("DEBUG: command: %s", groupCommand.c_str());
 }
 
 /**

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1195,55 +1195,48 @@ void SendGroupCommand(std::string who) {
 
 	// if auto save is enabled
 	if (AS_Config.OptAutoSave) {
-		instruction += "/autosize load ";
+		instruction = "/autosize load";
 	}
 	else {
 		// if auto save is not enabled, we have to go through every setting
 		// and create a command which covers both options and size values 
 		// in a single multiline command based on the current settings of
 		// the player instructing the synchronization to happen
-		instruction += "/multiline ; "; // must start with this as there are several instructions
+		instruction = "/multiline ; "; // must start with this as there are several instructions
+		
 		// autosave
-		if (AS_Config.OptAutoSave) {
-			instruction = "/autosize autosave on; ";
-		}
+		instruction += fmt::format("/autosize autosave {}; ", AS_Config.OptAutoSave ? "on" : "off");
+		
 		// zonewide and range
 		if (AS_Config.ResizeRange == FAR_CLIP_PLANE) {
 			// this covers the use case of the instructor having "zonewide" enabled
-			instruction = "/autosize on; ";
+			instruction += "/autosize on; ";
 		}
 		else if (AS_Config.ResizeRange != FAR_CLIP_PLANE) {
 			// this covers the use case of the instructor having "range" enabled
-			instruction = fmt::format("/autosize off; /autosize dist on; /autosize range {}; ", AS_Config.ResizeRange);
+			instruction += fmt::format("/autosize off; /autosize range {}; ", AS_Config.ResizeRange);
 		}
+		
 		// OptPC + SizePC
-		if (AS_Config.OptPC) {
-			instruction = fmt::format("/autosize pc on; /autosize sizepc {}; ", AS_Config.SizePC);
-		}
+		instruction += fmt::format("/autosize pc {}; /autosize sizepc {}; ", AS_Config.OptPC ? "on" : "off", AS_Config.SizePC);
+		
 		// OptNPC + SizeNPC
-		if (AS_Config.OptNPC) {
-			instruction = fmt::format("/autosize npc on; /autosize sizenpc {}; ", AS_Config.SizeNPC);
-		}
-		// OptPet + SizePet
-		if (AS_Config.OptPet) {
-			instruction = fmt::format("/autosize pets on; /autosize sizepets {}; ", AS_Config.SizePet);
-		}
-		// OptMerc + SizeMerc
-		if (AS_Config.OptMerc) {
-			instruction = fmt::format("/autosize mercs on; /autosize sizemercs {}; ", AS_Config.SizeMerc);
-		}
-		// OptMount + SizeMount
-		if (AS_Config.OptMount) {
-			instruction = fmt::format("/autosize mounts on; /autosize sizemounts {}; ", AS_Config.SizeMount);
-		}
-		// OptCorpse + SizeCorpse
-		if (AS_Config.OptCorpse) {
-			instruction = fmt::format("/autosize corpse on; /autosize sizecorpse {}; ", AS_Config.SizeCorpse);
-		}
+		instruction += fmt::format("/autosize npc {}; /autosize sizenpc {}; ", AS_Config.OptNPC ? "on" : "off", AS_Config.SizeNPC);
+				
+		// OptPet + SizePets
+		instruction += fmt::format("/autosize pets {}; /autosize sizepets {}; ", AS_Config.OptPet ? "on" : "off", AS_Config.SizePet);
+
+		// OptMerc + SizeMercs
+		instruction += fmt::format("/autosize mercs {}; /autosize sizemercs {}; ", AS_Config.OptMerc ? "on" : "off", AS_Config.SizeMerc);
+		
+		// OptMount + SizeMounts
+		instruction += fmt::format("/autosize mounts {}; /autosize sizemounts {}; ", AS_Config.OptMount ? "on" : "off", AS_Config.SizeMount);
+		
+		// OptCorpse + SizeCorpses
+		instruction += fmt::format("/autosize corpse {}; /autosize sizecorpse {}; ", AS_Config.OptCorpse ? "on" : "off", AS_Config.SizeCorpse);
+		
 		// OptSelf + SizeSelf
-		if (AS_Config.OptSelf) {
-			instruction = fmt::format("/autosize self on; /autosize sizeself {}; ", AS_Config.SizeSelf);
-		}
+		instruction += fmt::format("/autosize self {}; /autosize sizeself {}; ", AS_Config.OptSelf ? "on" : "off", AS_Config.SizeSelf);
 	}
 
 	if (selectedComms == static_cast<int>(CommunicationMode::DanNet)) {

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -944,10 +944,13 @@ void DrawAutoSize_MQSettingsPanel() {
 			}
 
 			ImGui::SeparatorText("Synchronize clients");
+			ImGui::BeginDisabled(loaded_dannet || loaded_eqbc);
 			if (ImGui::RadioButton("None", &selectedComms, static_cast<int>(CommunicationMode::None))) {
 				selectedComms = static_cast<int>(CommunicationMode::None);
 				return;
 			}
+			ImGui::EndDisabled();
+
 			ImGui::BeginDisabled(!loaded_dannet);
 			if (ImGui::RadioButton("MQ2DanNet", &selectedComms, static_cast<int>(CommunicationMode::DanNet))) {
 				selectedComms = static_cast<int>(CommunicationMode::DanNet);
@@ -1170,11 +1173,11 @@ void SendGroupCommand(std::string who) {
 
 	if (selectedComms == static_cast<int>(CommunicationMode::DanNet)) {
 		if (who == "zone")
-			groupCommand += fmt::format("/dgza {}", instruction);
+			groupCommand += fmt::format("/dgze {}", instruction);
 		else if (who == "raid")
-			groupCommand += fmt::format("/dgra {}", instruction);
+			groupCommand += fmt::format("/dgre {}", instruction);
 		else if (who == "group")
-			groupCommand += fmt::format("/dgga {}", instruction);
+			groupCommand += fmt::format("/dgge {}", instruction);
 		else if (who == "all")
 			groupCommand += fmt::format("/dge {}", instruction); // everyone but self since we already have it locally
 	}

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -596,12 +596,6 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 			// this means we are pretending to be Zonewide and need to revert to Range based
 			// we will do this by reseting the ResizeRange to what is in INI
 			emulate("range");
-
-			// TODO: DELETE
-			//AS_Config.ResizeRange = FAR_CLIP_PLANE;
-			//if (AS_Config.ResizeRange != FAR_CLIP_PLANE) {
-				//SetSizeConfig("range", previousRangeDistance, &AS_Config.ResizeRange);
-			//}
 		}
 		return;
 	}

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -9,26 +9,21 @@ constexpr const int MAX_SIZE = 250;                // Maximum size value
 constexpr int FAR_CLIP_PLANE = 1000;               // Placeholder for EQ Far Clip Plane value
 constexpr const float OTHER_SIZE = 1.0f;           // Default size for other entities
 constexpr const float ZERO_SIZE = 0.0f;            // Size representing zero
-constexpr const int DEFAULT_COMMS = 0;             // Default comms value
-constexpr const int DEFAULT_OPT_ZONEWIDE = 2;      // Default option for zonewide
 
 // Variables
 unsigned int uiSkipPulse = 0;            // Skip pulse counter
 char szTemp[MAX_STRING] = { 0 };         // Temporary buffer for strings
 int previousRangeDistance = 0;           // Previous range distance
-int selectedComms = DEFAULT_COMMS;       // Selected comms, updated in OnPulse
-int optZonewide = DEFAULT_OPT_ZONEWIDE;  // Option for zonewide, defaults to selecting Range
 bool loaded_dannet = false;              // State of DanNet plugin
 bool loaded_eqbc = false;                // State of EQBC plugin
-unsigned long long commsCheck;           // Comms check timestamp
-unsigned long long commsRefreshRateSeconds = 1;	// Refresh rate (seconds) used in OnPulse to check if comms plugins are available
+uint64_t commsCheck =0;                  // Comms check timestamp
 
 // Function Declarations
 void SpawnListResize(bool bReset);       // Function to resize the spawn list
 void ChooseInstructionPlugin();          // Function to choose the instruction plugin
-void emulate(const std::string& type);   // Function to emulate certain behavior (zonewide vs range)
+void emulate(const std::string_view type);   // Function to emulate certain behavior (zonewide vs range)
 void DrawAutoSize_MQSettingsPanel();     // Function to draw the MQ settings panel
-void SendGroupCommand(const std::string& who); // Function to send a command to a group
+void SendGroupCommand(const std::string_view who); // Function to send a command to a group
 int RoundToNearestTen(int value);        // Function to round a value to the nearest ten
 static bool isInGroup();                 // Function to check if in a group
 static bool isInRaid();                  // Function to check if in a raid
@@ -37,58 +32,55 @@ static bool isInRaid();                  // Function to check if in a raid
 PreSetup("MQ2AutoSize");
 PLUGIN_VERSION(1.1);
 
-enum class CommunicationMode
+enum class eCommunicationMode
 {
 	None = 0,
 	DanNet = 1,
-	EQBC = 2
-};
+	EQBC = 2,
 
-enum class ResizeMode
+	Default = 0
+};
+int selectedComms = static_cast<int>(eCommunicationMode::Default);
+
+enum class eResizeMode
 {
 	None = 0,
 	Zonewide = 1,
-	Range = 2
+	Range = 2,
+
+	Default = 2
 };
+int ResizeMode = static_cast<int>(eResizeMode::Default);
 
 // our configuration
 class COurSizes
 {
 public:
-	COurSizes()
-	{
-		OptPC = true;
-		OptNPC = OptPet = OptMerc = OptMount = OptCorpse = OptSelf = OptAutoSave = false;
-		ResizeRange = 50;
-		SizePC = SizeNPC = SizePet = SizeMerc = SizeMount = SizeCorpse = SizeSelf = 1;
-	};
-
-	bool OptAutoSave;
-	bool OptPC;
-	bool OptNPC;
-	bool OptPet;
-	bool OptMerc;
-	bool OptMount;
-	bool OptCorpse;
-	bool OptSelf;
-
-	int ResizeRange;
-	int SizePC;
-	int SizeNPC;
-	int SizePet;
-	int SizeMerc;
-	int SizeMount;
-	int SizeCorpse;
-	int SizeSelf;
+	COurSizes() = default;
+	bool OptAutoSave = 0;
+	bool OptPC = 1;
+	bool OptNPC = 0;
+	bool OptPet = 0;
+	bool OptMerc = 0;
+	bool OptMount = 0;
+	bool OptCorpse = 0;
+	bool OptSelf = 0;
+	int ResizeRange = 50;
+	int SizePC  = 1;
+	int SizeNPC = 1;
+	int SizePet = 1;
+	int SizeMerc = 1;
+	int SizeMount = 1;
+	int SizeCorpse = 1;
+	int SizeSelf = 1;
 };
 COurSizes AS_Config;
 
 // exposed TLO variables
-class MQ2AutoSizeType* pAutoSizeType = 0;
 class MQ2AutoSizeType : public MQ2Type
 {
 public:
-	enum AutoSizeMembers
+	enum class AutoSizeMembers
 	{
 		Active,
 		AutoSave,
@@ -109,25 +101,25 @@ public:
 		SizeSelf
 	};
 
-	MQ2AutoSizeType() :MQ2Type("AutoSize")
+	MQ2AutoSizeType() : MQ2Type("AutoSize")
 	{
-		TypeMember(Active);
-		TypeMember(AutoSave);
-		TypeMember(ResizePC);
-		TypeMember(ResizeNPC);
-		TypeMember(ResizePets);
-		TypeMember(ResizeMercs);
-		TypeMember(ResizeMounts);
-		TypeMember(ResizeCorpse);
-		TypeMember(ResizeSelf);
-		TypeMember(Range);
-		TypeMember(SizePC);
-		TypeMember(SizeNPC);
-		TypeMember(SizePets);
-		TypeMember(SizeMercs);
-		TypeMember(SizeMounts);
-		TypeMember(SizeCorpse);
-		TypeMember(SizeSelf);
+		ScopedTypeMember(AutoSizeMembers, Active);
+		ScopedTypeMember(AutoSizeMembers, AutoSave);
+		ScopedTypeMember(AutoSizeMembers, ResizePC);
+		ScopedTypeMember(AutoSizeMembers, ResizeNPC);
+		ScopedTypeMember(AutoSizeMembers, ResizePets);
+		ScopedTypeMember(AutoSizeMembers, ResizeMercs);
+		ScopedTypeMember(AutoSizeMembers, ResizeMounts);
+		ScopedTypeMember(AutoSizeMembers, ResizeCorpse);
+		ScopedTypeMember(AutoSizeMembers, ResizeSelf);
+		ScopedTypeMember(AutoSizeMembers, Range);
+		ScopedTypeMember(AutoSizeMembers, SizePC);
+		ScopedTypeMember(AutoSizeMembers, SizeNPC);
+		ScopedTypeMember(AutoSizeMembers, SizePets);
+		ScopedTypeMember(AutoSizeMembers, SizeMercs);
+		ScopedTypeMember(AutoSizeMembers, SizeMounts);
+		ScopedTypeMember(AutoSizeMembers, SizeCorpse);
+		ScopedTypeMember(AutoSizeMembers, SizeSelf);
 	}
 
 	~MQ2AutoSizeType() {}
@@ -141,71 +133,71 @@ public:
 
 		switch ((AutoSizeMembers)pMember->ID)
 		{
-			case Active:
+			case AutoSizeMembers::Active:
 				Dest.Int = AS_Config.OptPC || AS_Config.OptNPC || AS_Config.OptPet || AS_Config.OptMerc || AS_Config.OptMount || AS_Config.OptCorpse || AS_Config.OptSelf;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case AutoSave:
+			case AutoSizeMembers::AutoSave:
 				Dest.Int = AS_Config.OptAutoSave;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case ResizePC:
+			case AutoSizeMembers::ResizePC:
 				Dest.Int = AS_Config.OptPC;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case ResizeNPC:
+			case AutoSizeMembers::ResizeNPC:
 				Dest.Int = AS_Config.OptNPC;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case ResizePets:
+			case AutoSizeMembers::ResizePets:
 				Dest.Int = AS_Config.OptPet;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case ResizeMercs:
+			case AutoSizeMembers::ResizeMercs:
 				Dest.Int = AS_Config.OptMerc;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case ResizeMounts:
+			case AutoSizeMembers::ResizeMounts:
 				Dest.Int = AS_Config.OptMount;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case ResizeCorpse:
+			case AutoSizeMembers::ResizeCorpse:
 				Dest.Int = AS_Config.OptCorpse;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case ResizeSelf:
+			case AutoSizeMembers::ResizeSelf:
 				Dest.Int = AS_Config.OptSelf;
 				Dest.Type = datatypes::pBoolType;
 				return true;
-			case Range:
+			case AutoSizeMembers::Range:
 				Dest.Int = AS_Config.ResizeRange;
 				Dest.Type = datatypes::pIntType;
 				return true;
-			case SizePC:
+			case AutoSizeMembers::SizePC:
 				Dest.Int = AS_Config.SizePC;
 				Dest.Type = datatypes::pIntType;
 				return true;
-			case SizeNPC:
+			case AutoSizeMembers::SizeNPC:
 				Dest.Int = AS_Config.SizeNPC;
 				Dest.Type = datatypes::pIntType;
 				return true;
-			case SizePets:
+			case AutoSizeMembers::SizePets:
 				Dest.Int = AS_Config.SizePet;
 				Dest.Type = datatypes::pIntType;
 				return true;
-			case SizeMercs:
+			case AutoSizeMembers::SizeMercs:
 				Dest.Int = AS_Config.SizeMerc;
 				Dest.Type = datatypes::pIntType;
 				return true;
-			case SizeMounts:
+			case AutoSizeMembers::SizeMounts:
 				Dest.Int = AS_Config.SizeMount;
 				Dest.Type = datatypes::pIntType;
 				return true;
-			case SizeCorpse:
+			case AutoSizeMembers::SizeCorpse:
 				Dest.Int = AS_Config.SizeCorpse;
 				Dest.Type = datatypes::pIntType;
 				return true;
-			case SizeSelf:
+			case AutoSizeMembers::SizeSelf:
 				Dest.Int = AS_Config.SizeSelf;
 				Dest.Type = datatypes::pIntType;
 				return true;
@@ -215,9 +207,11 @@ public:
 
 	bool ToString(MQVarPtr VarPtr, char* Destination)
 	{
+		strcpy_s(Destination, MAX_STRING, "AutoSize");
 		return true;
 	}
 };
+MQ2AutoSizeType* pAutoSizeType = 0;
 
 bool dataAutoSize(const char* szIndex, MQTypeVar& ret)
 {
@@ -252,22 +246,6 @@ public:
 };
 
 /**
- * This function reads a string value from a specified section and key in an INI file.
- * It then performs a case-insensitive comparison to check if the value is "on".
- *
- * @param section The section in the INI file to read from.
- * @param key The key in the section to read the value of.
- * @param defaultValue The default value to use if the key is not found.
- * @return true if the retrieved value is "on" (case-insensitively), false otherwise.
- */
-static bool getOptionValue(const char* section, const char* key, const char* defaultValue)
-{
-	char szTemp[MAX_STRING] = { 0 };
-	GetPrivateProfileString(section, key, defaultValue, szTemp, MAX_STRING, INIFileName);
-	return (ci_equals(szTemp, "on"));
-}
-
-/**
  * This function reads an integer value from a specified section and key in an INI file.
  * It then clamps the value to ensure it falls within the specified minimum and maximum size range.
  * If the pulled value is lower than MIN_SIZE then it will be set to MIN_SIZE value
@@ -278,23 +256,23 @@ static bool getOptionValue(const char* section, const char* key, const char* def
  * @param defaultValue The default value to use if the key is not found or the value is invalid.
  * @return An integer representing the size value, clamped to be within the range of MIN_SIZE and MAX_SIZE.
  */
-static int getSaneSize(const std::string& section, const std::string& key, int defaultValue)
+static int getSaneSize(const char* section, const char* key, int defaultValue)
 {
-	int size = GetPrivateProfileInt(section.c_str(), key.c_str(), defaultValue, INIFileName);
+	int size = GetPrivateProfileInt(section, key, defaultValue, INIFileName);
 	return std::clamp(size, MIN_SIZE, MAX_SIZE);
 }
 
 void LoadINI()
 {
-	// defaulted options to off
-	AS_Config.OptAutoSave = getOptionValue("Config", "AutoSave", "off");
-	AS_Config.OptPC = getOptionValue("Config", "ResizePC", "off");
-	AS_Config.OptNPC = getOptionValue("Config", "ResizeNPC", "off");
-	AS_Config.OptPet = getOptionValue("Config", "ResizePets", "off");
-	AS_Config.OptMerc = getOptionValue("Config", "ResizeMercs", "off");
-	AS_Config.OptMount = getOptionValue("Config", "ResizeMounts", "off");
-	AS_Config.OptCorpse = getOptionValue("Config", "ResizeCorpse", "off");
-	AS_Config.OptSelf = getOptionValue("Config", "ResizeSelf", "off");
+	AS_Config.OptAutoSave = GetPrivateProfileBool("Config", "AutoSave", "on", INIFileName);
+	AS_Config.OptPC = GetPrivateProfileBool("Config", "ResizePC", "off", INIFileName);
+	AS_Config.OptNPC = GetPrivateProfileBool("Config", "ResizeNPC", "off", INIFileName);
+	AS_Config.OptPet = GetPrivateProfileBool("Config", "ResizePets", "off", INIFileName);
+	AS_Config.OptMerc = GetPrivateProfileBool("Config", "ResizeMercs", "off", INIFileName);
+	AS_Config.OptMount = GetPrivateProfileBool("Config", "ResizeMounts", "off", INIFileName);
+	AS_Config.OptCorpse = GetPrivateProfileBool("Config", "ResizeCorpse", "off", INIFileName);
+	AS_Config.OptSelf = GetPrivateProfileBool("Config", "ResizeSelf", "off", INIFileName);
+
 	AS_Config.ResizeRange = getSaneSize("Config", "Range", AS_Config.ResizeRange);
 	AS_Config.SizePC = getSaneSize("Config", "SizePC", MIN_SIZE);
 	AS_Config.SizeNPC = getSaneSize("Config", "SizeNPC", MIN_SIZE);
@@ -317,7 +295,7 @@ void LoadINI()
 void SaveINI(const std::string& param = "", const bool squelch = 0)
 {
 	// Map to store configuration key-value pairs
-	std::map<std::string, std::string> configMap =
+	std::vector<std::pair<std::string, std::string>> configMap =
 	{
 		{"AutoSave", AS_Config.OptAutoSave ? "on" : "off"},
 		{"ResizePC", AS_Config.OptPC ? "on" : "off"},
@@ -339,7 +317,7 @@ void SaveINI(const std::string& param = "", const bool squelch = 0)
 	// this writes a specific key to disk with its value
 	if (!param.empty())
 	{
-		auto it = configMap.find(param);
+		auto it = std::find_if(configMap.begin(), configMap.end(), [&](const auto& p) { return p.first == param; });
 		if (it != configMap.end())
 		{
 			WritePrivateProfileString("Config", it->first, it->second, INIFileName);
@@ -380,17 +358,16 @@ void ChangeSize(PlayerClient* pChangeSpawn, float fNewSize)
 	}
 }
 
-void SizePasser(PSPAWNINFO pSpawn, bool bReset)
+void SizePasser(PlayerClient* pSpawn, bool bReset)
 {
 	if (GetGameState() != GAMESTATE_INGAME)
 	{
 		return;
 	}
 
-	PSPAWNINFO pLPlayer = (PSPAWNINFO)pLocalPlayer;
-	if (!pLPlayer || !pLPlayer->SpawnID || !pSpawn || !pSpawn->SpawnID) return;
+	if (!pLocalPlayer || !pSpawn) return;
 
-	if (pSpawn->SpawnID == pLPlayer->SpawnID)
+	if (pSpawn->SpawnID == pLocalPlayer->SpawnID)
 	{
 		if (AS_Config.OptSelf) ChangeSize(pSpawn, bReset ? ZERO_SIZE : AS_Config.SizeSelf);
 		return;
@@ -427,7 +404,7 @@ void SizePasser(PSPAWNINFO pSpawn, bool bReset)
 			}
 			break;
 		case MOUNT:
-			if (AS_Config.OptMount && pSpawn->SpawnID != pLPlayer->SpawnID)
+			if (AS_Config.OptMount && pSpawn->SpawnID != pLocalPlayer->SpawnID)
 			{
 				ChangeSize(pSpawn, bReset ? ZERO_SIZE : AS_Config.SizeMount);
 				return;
@@ -447,16 +424,15 @@ void SizePasser(PSPAWNINFO pSpawn, bool bReset)
 
 void ResetAllByType(eSpawnType OurType)
 {
-	PSPAWNINFO pSpawn = (PSPAWNINFO)pSpawnList;
-	PSPAWNINFO pLPlayer = (PSPAWNINFO)pLocalPlayer;
-	if (GetGameState() != GAMESTATE_INGAME || !pLPlayer || !pLPlayer->SpawnID || !pSpawn || !pSpawn->SpawnID)
+	PlayerClient* pSpawn = pSpawnList;
+	if (GetGameState() != GAMESTATE_INGAME || !pLocalPlayer || !pSpawn)
 	{
 		return;
 	}
 
 	while (pSpawn)
 	{
-		if (pSpawn->SpawnID == pLPlayer->SpawnID)
+		if (pSpawn->SpawnID == pLocalPlayer->SpawnID)
 		{
 			pSpawn = pSpawn->pNext;
 			continue;
@@ -477,18 +453,14 @@ void ResetAllByType(eSpawnType OurType)
 void SpawnListResize(bool bReset)
 {
 	if (GetGameState() != GAMESTATE_INGAME) return;
-	PSPAWNINFO pSpawn = (PSPAWNINFO)pSpawnList;
-	while (pSpawn)
+	PlayerClient* pAllSpawns = pSpawnList;
+	while (pAllSpawns)
 	{
-		SizePasser(pSpawn, bReset);
-		pSpawn = pSpawn->pNext;
+		SizePasser(pAllSpawns, bReset);
+		pAllSpawns = pAllSpawns->pNext;
 	}
 }
 
-PLUGIN_API void OnAddSpawn(PSPAWNINFO pNewSpawn)
-{
-	// nothing additional to perform over existing functionality
-}
 
 PLUGIN_API void OnEndZone()
 {
@@ -508,20 +480,21 @@ PLUGIN_API void OnPulse()
 		return;
 	}
 
-	// check if communication plugins are still running and adjust UI as needed
-	if (GetTickCount64() > commsCheck)
+	// refresh comms due to OnLoadPlugin or OnUnloadPlugin event
+	if (commsCheck > 0 && GetTickCount64() > commsCheck)
 	{
-		commsCheck = std::int64_t(commsCheck) + (static_cast<long long>(commsRefreshRateSeconds) * 1000);
+		// reset commsCheck until triggered event
+		commsCheck = 0;
 		ChooseInstructionPlugin();
 	}
 	
-	PSPAWNINFO pAllSpawns = (PSPAWNINFO)pSpawnList;
+	PlayerClient* pAllSpawns = pSpawnList;
 	float fDist = 0.0f;
 	uiSkipPulse = 0;
 
 	while (pAllSpawns)
 	{
-		fDist = GetDistance((PSPAWNINFO)pLocalPlayer, pAllSpawns);
+		fDist = GetDistance(pLocalPlayer, pAllSpawns);
 		if (fDist < AS_Config.ResizeRange)
 		{
 			SizePasser(pAllSpawns, false);
@@ -542,7 +515,7 @@ void OutputHelp()
 	WriteChatf("  \ag/autosize\ax \ayrange #\ax - Sets range for distance checking");
 	WriteChatf("--- Valid Resize Toggles ---");
 	WriteChatf("  \ag/autosize\ax [ \aypc\ax | \aynpc\ax | \aypets\ax | \aymercs\ax | \aymounts\ax | \aycorpse\ax | \ayeverything\ax | \ayself\ax ]");
-	WriteChatf("--- Valid Size Syntax (1 to 250) ---");
+	WriteChatf("--- Valid Size Syntax (%d to %d) ---", MIN_SIZE, MAX_SIZE);
 	WriteChatf("  \ag/autosize\ax [ \aysizepc\ax | \aysizenpc\ax | \aysizepets\ax | \aysizemercs\ax | \aysizemounts\ax | \aysizecorpse\ax | \aysizeself\ax ] [ \ay#\ax ]");
 	WriteChatf("--- Other Valid Commands ---");
 	WriteChatf("  \ag/autosize\ax [ \ayhelp\ax | \aystatus\ax | \ayautosave\ax | \aysave\ax | \ayload\ax ]");
@@ -559,7 +532,7 @@ void OutputStatus()
 	// replaced above with a more direct feedback
 	if (!AS_Config.OptPC && !AS_Config.OptNPC && !AS_Config.OptPet && !AS_Config.OptMerc && !AS_Config.OptCorpse && !AS_Config.OptSelf)
 	{
-		sprintf_s(szMethod, "\arInactive\ax");
+		strcpy_s(szMethod, "\arInactive\ax");
 	}
 	else if (AS_Config.ResizeRange < FAR_CLIP_PLANE)
 	{
@@ -568,7 +541,7 @@ void OutputStatus()
 	else if (AS_Config.ResizeRange == FAR_CLIP_PLANE)
 	{
 		// covers the idea of Zonewide by using FAR_CLIP_PLANE value (which is about 100% Far Cliping Plane)
-		sprintf_s(szMethod, "\ayZonewide\ax");
+		strcpy_s(szMethod, "\ayZonewide\ax");
 	}
 
 	WriteChatf("\ay%s\aw:: Current Status -- Method: (%s)%s", mqplugin::PluginName, szMethod, AS_Config.OptAutoSave ? " \agAUTOSAVING" : "");
@@ -605,6 +578,14 @@ bool ToggleOption(const char* pszToggleOutput, bool* pbOption)
 	return *pbOption;
 }
 
+void SetOption(const char* optString, bool* pbOption, bool bValue)
+{
+	*pbOption = bValue;
+	WriteChatf("\ay%s\aw:: Option (\ay%s\ax) now %s\ax", mqplugin::PluginName, optString, *pbOption ? "\agenabled" : "\ardisabled");
+	if (AS_Config.OptAutoSave) SaveINI();
+	return;
+}
+
 void SetSizeConfig(const char* pszOption, int iNewSize, int* iOldSize)
 {
 	// special handling for Range being set to Zonewide
@@ -632,13 +613,13 @@ void SetSizeConfig(const char* pszOption, int iNewSize, int* iOldSize)
 	if (AS_Config.OptAutoSave) SaveINI();
 }
 
-void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
+void AutoSizeCmd(PlayerClient* pLPlayer, const char* szLine)
 {
 	char szCurArg[MAX_STRING] = { 0 };
 	char szNumber[MAX_STRING] = { 0 };
 	GetArg(szCurArg, szLine, 1);
 	GetArg(szNumber, szLine, 2);
-	int iNewSize = std::atoi(szNumber);
+	int iNewSize = GetIntFromString(szNumber, MIN_SIZE);
 
 	if (!*szCurArg)
 	{
@@ -675,7 +656,7 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 				emulate("zonewide");
 			}
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			if (AS_Config.ResizeRange == FAR_CLIP_PLANE)
 			{
@@ -702,19 +683,15 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 	{
 		if (ci_equals(szNumber, "on"))
 		{
-			if (!AS_Config.OptAutoSave)
-			{
-				ToggleOption("Autosave", &AS_Config.OptAutoSave);
-			}
+			SetOption("Autosave", &AS_Config.OptAutoSave, true);
+
 		}
 		else if (ci_equals(szNumber, "off"))
 		{
-			if (AS_Config.OptAutoSave)
-			{
-				ToggleOption("Autosave", &AS_Config.OptAutoSave);
-			}
+			SetOption("Autosave", &AS_Config.OptAutoSave, false);
+
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			ToggleOption("Autosave", &AS_Config.OptAutoSave);
 		}
@@ -759,16 +736,17 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 	}
 	else if (ci_equals(szCurArg, "pc"))
 	{
-		if (ci_equals(szNumber, "on") && !AS_Config.OptPC)
+		if (ci_equals(szNumber, "on"))
 		{
-			ToggleOption("PC", &AS_Config.OptPC);
+			SetOption("PC", &AS_Config.OptPC, true);
+
 		}
-		else if (ci_equals(szNumber, "off") && AS_Config.OptPC)
+		else if (ci_equals(szNumber, "off"))
 		{
-			ToggleOption("PC", &AS_Config.OptPC);
+			SetOption("PC", &AS_Config.OptPC, false);
 			ResetAllByType(PC);
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			if (!ToggleOption("PC", &AS_Config.OptPC))
 			{
@@ -779,16 +757,16 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 	}
 	else if (ci_equals(szCurArg, "npc"))
 	{
-		if (ci_equals(szNumber, "on") && !AS_Config.OptNPC)
+		if (ci_equals(szNumber, "on"))
 		{
-			ToggleOption("NPC", &AS_Config.OptNPC);
+			SetOption("NPC", &AS_Config.OptNPC, true);
 		}
-		else if (ci_equals(szNumber, "off") && AS_Config.OptNPC)
+		else if (ci_equals(szNumber, "off"))
 		{
-			ToggleOption("NPC", &AS_Config.OptNPC);
+			SetOption("NPC", &AS_Config.OptNPC, false);
 			ResetAllByType(NPC);
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			if (!ToggleOption("NPC", &AS_Config.OptNPC))
 			{
@@ -801,45 +779,45 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 	{
 		if (!AS_Config.OptSelf)
 		{
-			DoCommandf("/squelch /autosize self");
+			EzCommand("/squelch /autosize self on");
 		}
 		if (!AS_Config.OptCorpse)
 		{
-			DoCommandf("/squelch /autosize corpse");
+			EzCommand("/squelch /autosize corpse on");
 		}
 		if (!AS_Config.OptMerc)
 		{
-			DoCommandf("/squelch /autosize mercs");
+			EzCommand("/squelch /autosize mercs on");
 		}
 		if (!AS_Config.OptMount)
 		{
-			DoCommandf("/squelch /autosize mounts");
+			EzCommand("/squelch /autosize mounts on");
 		}
 		if (!AS_Config.OptNPC)
 		{
-			DoCommandf("/squelch /autosize npc");
+			EzCommand("/squelch /autosize npc on");
 		}
 		if (!AS_Config.OptPC)
 		{
-			DoCommandf("/squelch /autosize pc");
+			EzCommand("/squelch /autosize pc on");
 		}
 		if (!AS_Config.OptPet)
 		{
-			DoCommandf("/squelch /autosize pets");
+			EzCommand("/squelch /autosize pets on");
 		}		
 	}
 	else if (ci_equals(szCurArg, "pets"))
 	{
-		if (ci_equals(szNumber, "on") && !AS_Config.OptPet)
+		if (ci_equals(szNumber, "on"))
 		{
-			ToggleOption("Pets", &AS_Config.OptPet);
+			SetOption("Pets", &AS_Config.OptPet, true);
 		}
-		else if (ci_equals(szNumber, "off") && AS_Config.OptPet)
+		else if (ci_equals(szNumber, "off"))
 		{
-			ToggleOption("Pets", &AS_Config.OptPet);
+			SetOption("Pets", &AS_Config.OptPet, false);
 			ResetAllByType(PET);
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			if (!ToggleOption("Pets", &AS_Config.OptPet))
 			{
@@ -850,16 +828,16 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 	}
 	else if (ci_equals(szCurArg, "mercs"))
 	{
-		if (ci_equals(szNumber, "on") && !AS_Config.OptMerc)
+		if (ci_equals(szNumber, "on"))
 		{
-			ToggleOption("Mercs", &AS_Config.OptMerc);
+			SetOption("Mercs", &AS_Config.OptMerc, true);
 		}
-		else if (ci_equals(szNumber, "off") && AS_Config.OptMerc)
+		else if (ci_equals(szNumber, "off"))
 		{
-			ToggleOption("Mercs", &AS_Config.OptMerc);
+			SetOption("Mercs", &AS_Config.OptMerc, false);
 			ResetAllByType(MERCENARY);
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			if (!ToggleOption("Mercs", &AS_Config.OptMerc))
 			{
@@ -870,16 +848,16 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 	}
 	else if (ci_equals(szCurArg, "mounts"))
 	{
-		if (ci_equals(szNumber, "on") && !AS_Config.OptMount)
+		if (ci_equals(szNumber, "on"))
 		{
-			ToggleOption("Mounts", &AS_Config.OptMount);
+			SetOption("Mounts", &AS_Config.OptMount, true);
 		}
-		else if (ci_equals(szNumber, "off") && AS_Config.OptMount)
+		else if (ci_equals(szNumber, "off"))
 		{
-			ToggleOption("Mounts", &AS_Config.OptMount);
+			SetOption("Mounts", &AS_Config.OptMount, false);
 			ResetAllByType(MOUNT);
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			if (!ToggleOption("Mounts", &AS_Config.OptMount))
 			{
@@ -890,16 +868,16 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 	}
 	else if (ci_equals(szCurArg, "corpse"))
 	{
-		if (ci_equals(szNumber, "on") && !AS_Config.OptCorpse)
+		if (ci_equals(szNumber, "on"))
 		{
-			ToggleOption("Corpses", &AS_Config.OptCorpse);
+			SetOption("Corpses", &AS_Config.OptCorpse, true);
 		}
-		else if (ci_equals(szNumber, "off") && AS_Config.OptCorpse)
+		else if (ci_equals(szNumber, "off"))
 		{
-			ToggleOption("Corpses", &AS_Config.OptCorpse);
+			SetOption("Corpses", &AS_Config.OptCorpse, false);
 			ResetAllByType(CORPSE);
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			if (!ToggleOption("Corpses", &AS_Config.OptCorpse))
 			{
@@ -916,20 +894,20 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 	}
 	else if (ci_equals(szCurArg, "self"))
 	{
-		if (ci_equals(szNumber, "on") && !AS_Config.OptSelf)
+		if (ci_equals(szNumber, "on"))
 		{
-			ToggleOption("Self", &AS_Config.OptSelf);
+			SetOption("Self", &AS_Config.OptSelf, true);
 		}
-		else if (ci_equals(szNumber, "off") && AS_Config.OptSelf)
+		else if (ci_equals(szNumber, "off"))
 		{
-			ToggleOption("Self", &AS_Config.OptSelf);
-			ChangeSize((PSPAWNINFO)pLocalPlayer, ZERO_SIZE);
+			SetOption("Self", &AS_Config.OptSelf, false);
+			ChangeSize(pLocalPlayer, ZERO_SIZE);
 		}
-		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off"))
+		else
 		{
 			if (!ToggleOption("Self", &AS_Config.OptSelf))
 			{
-				ChangeSize((PSPAWNINFO)pLocalPlayer, ZERO_SIZE);
+				ChangeSize(pLocalPlayer, ZERO_SIZE);
 			}
 		}
 		return;
@@ -967,6 +945,7 @@ PLUGIN_API void InitializePlugin()
 	AddCommand("/autosize", AutoSizeCmd);
 	AddSettingsPanel("plugins/AutoSize", DrawAutoSize_MQSettingsPanel);
 	LoadINI();
+	ChooseInstructionPlugin();
 }
 
 PLUGIN_API void ShutdownPlugin()
@@ -983,11 +962,43 @@ PLUGIN_API void ShutdownPlugin()
 	delete pAutoSizeType;
 }
 
+PLUGIN_API void OnLoadPlugin(const char* pluginName)
+{
+	if (ci_equals(pluginName, "MQ2DanNet"))
+	{
+		
+	}
+
+	if (ci_equals(pluginName, "MQ2EQBC"))
+	{
+
+	}
+}
+
+PLUGIN_API void OnUnloadPlugin(const char* pluginName)
+{
+	if (ci_equals(pluginName, "MQ2DanNet"))
+	{
+		// dannet plugin is about to unload
+		// maybe set commsCheck to time in the future, like a second or two
+		// then in OnPulse check that commsCheck > 0 and current time is 
+		// greater than the time and then set commsCheck back to 0 to avoid
+		// future rechecking, until one of these triggers occur
+		loaded_dannet = false;
+		commsCheck = GetTickCount64() + 1000;
+	}
+
+	if (ci_equals(pluginName, "MQ2EQBC"))
+	{
+		loaded_eqbc = false;
+		commsCheck = GetTickCount64() + 1000;
+	}
+}
+
 void DrawAutoSize_MQSettingsPanel()
 {
 	ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "MQ2AutoSize");
-	ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_None;
-	if (ImGui::BeginTabBar("AutoSizeTabBar", tab_bar_flags))
+	if (ImGui::BeginTabBar("AutoSizeTabBar"))
 	{
 		if (ImGui::BeginTabItem("Options"))
 		{
@@ -995,13 +1006,12 @@ void DrawAutoSize_MQSettingsPanel()
 			// General: auto save
 			if (ImGui::Checkbox("Enable auto saving of configuration", &AS_Config.OptAutoSave))
 			{
-				AS_Config.OptAutoSave = !AS_Config.OptAutoSave;
-				DoCommandf("/autosize autosave");
+				DoCommandf("/autosize autosave %s", AS_Config.OptAutoSave ? "on" : "off");
 			}
-			// General: Zodewide
-			if (ImGui::RadioButton("Zonewide (max clipping plane)", &optZonewide, static_cast<int>(ResizeMode::Zonewide)))
+			// General: Zonewide
+			if (ImGui::RadioButton("Zonewide (max clipping plane)", &ResizeMode, static_cast<int>(eResizeMode::Zonewide)))
 			{
-				optZonewide = static_cast<int>(ResizeMode::Zonewide);
+				ResizeMode = static_cast<int>(eResizeMode::Zonewide);
 				emulate("zonewide");
 			}
 			// General: Range
@@ -1010,15 +1020,15 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 20.0f);
 				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
 				ImGui::TableNextColumn();
-				if (ImGui::RadioButton("", &optZonewide, static_cast<int>(ResizeMode::Range)))
+				if (ImGui::RadioButton("##rangeselector", &ResizeMode, static_cast<int>(eResizeMode::Range)))
 				{
-					optZonewide = static_cast<int>(ResizeMode::Range);
+					ResizeMode = static_cast<int>(eResizeMode::Range);
 					emulate("range");
 				}
 				ImGui::TableNextColumn();
-				ImGui::BeginDisabled(optZonewide == static_cast<int>(ResizeMode::Zonewide));
-				ImGui::PushItemWidth(50.0f);
-				if (ImGui::SliderInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 10, 250, "%d", ImGuiSliderFlags_NoInput|ImGuiSliderFlags_AlwaysClamp))
+				ImGui::BeginDisabled(ResizeMode == static_cast<int>(eResizeMode::Zonewide));
+				ImGui::SetNextItemWidth(50.0f);
+				if (ImGui::SliderInt("Range distance (recommended setting)", &AS_Config.ResizeRange, 10, MAX_SIZE, "%d", ImGuiSliderFlags_NoInput|ImGuiSliderFlags_AlwaysClamp))
 				{
 					AS_Config.ResizeRange = RoundToNearestTen(AS_Config.ResizeRange);
 					if (AS_Config.OptAutoSave)
@@ -1043,13 +1053,12 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextColumn();
 				if (ImGui::Checkbox("##OptSelf", &AS_Config.OptSelf))
 				{
-					AS_Config.OptSelf = !AS_Config.OptSelf;
-					DoCommandf("/autosize self");
+					DoCommandf("/autosize self %s", AS_Config.OptSelf ? "on" : "off");
 				}
 				ImGui::TableNextColumn();
 				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptSelf);
-				if (ImGui::SliderInt("Resize: Self##inputSS", &AS_Config.SizeSelf, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
+				if (ImGui::SliderInt("Resize: Self", &AS_Config.SizeSelf, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
 				{
 					if (AS_Config.OptAutoSave)
 					{
@@ -1062,13 +1071,12 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextColumn();
 				if (ImGui::Checkbox("##OptPC", &AS_Config.OptPC))
 				{
-					AS_Config.OptPC = !AS_Config.OptPC;
-					DoCommandf("/autosize pc");
+					DoCommandf("/autosize pc %s", AS_Config.OptPC ? "on" : "off");
 				}
 				ImGui::TableNextColumn();
 				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptPC);
-				if (ImGui::SliderInt("Resize: Other player(s) (incluldes those mounted)##inputOP", &AS_Config.SizePC, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
+				if (ImGui::SliderInt("Resize: Other player(s) (incluldes those mounted)", &AS_Config.SizePC, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
 				{
 					if (AS_Config.OptAutoSave)
 					{
@@ -1080,18 +1088,17 @@ void DrawAutoSize_MQSettingsPanel()
 				// Option: Pets
 				ImGui::TableNextColumn();
 				if (ImGui::Checkbox("##OptPet", &AS_Config.OptPet))
-				{
-					AS_Config.OptPet = !AS_Config.OptPet;
-					DoCommandf("/autosize pets");
+				{;
+					DoCommandf("/autosize pets %s", AS_Config.OptPet ? "on" : "off");
 				}
 				ImGui::TableNextColumn();
-				ImGui::PushItemWidth(50.0f);
+				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptPet);
-				if (ImGui::SliderInt("Resize: Pets##inputPS", &AS_Config.SizePet, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
+				if (ImGui::SliderInt("Resize: Pets", &AS_Config.SizePet, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
 				{
 					if (AS_Config.OptAutoSave)
 					{
-						SaveINI("SizePet", true);
+						SaveINI("SizePets", true);
 					}
 				}
 				ImGui::EndDisabled();
@@ -1100,17 +1107,16 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextColumn();
 				if (ImGui::Checkbox("##OptMerc", &AS_Config.OptMerc))
 				{
-					AS_Config.OptMerc = !AS_Config.OptMerc;
-					DoCommandf("/autosize mercs");
+					DoCommandf("/autosize mercs %s", AS_Config.OptMerc ? "on" : "off");
 				}
 				ImGui::TableNextColumn();
-				ImGui::PushItemWidth(50.0f);
+				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptMerc);
-				if (ImGui::SliderInt("Resize: Mercs##inputMercSize", &AS_Config.SizeMerc, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
+				if (ImGui::SliderInt("Resize: Mercs", &AS_Config.SizeMerc, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
 				{
 					if (AS_Config.OptAutoSave)
 					{
-						SaveINI("SizeMerc", true);
+						SaveINI("SizeMercs", true);
 					}
 				}
 				ImGui::EndDisabled();
@@ -1119,17 +1125,16 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextColumn();
 				if (ImGui::Checkbox("##OptMount", &AS_Config.OptMount))
 				{
-					AS_Config.OptMount = !AS_Config.OptMount;
-					DoCommandf("/autosize mounts");
+					DoCommandf("/autosize mounts %s", AS_Config.OptMount ? "on" : "off");
 				}
 				ImGui::TableNextColumn();
-				ImGui::PushItemWidth(50.0f);
+				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptMount);
-				if (ImGui::SliderInt("Resize: Mounts and the Player(s) on them##inputMountSize", &AS_Config.SizeMount, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
+				if (ImGui::SliderInt("Resize: Mounts and the Player(s) on them", &AS_Config.SizeMount, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
 				{
 					if (AS_Config.OptAutoSave)
 					{
-						SaveINI("SizeMount", true);
+						SaveINI("SizeMounts", true);
 					}
 				}
 				ImGui::EndDisabled();
@@ -1138,13 +1143,12 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextColumn();
 				if (ImGui::Checkbox("##OptCorpse", &AS_Config.OptCorpse))
 				{
-					AS_Config.OptCorpse = !AS_Config.OptCorpse;
-					DoCommandf("/autosize corpse");
+					DoCommandf("/autosize corpse %s", AS_Config.OptCorpse ? "on" : "off");
 				}
 				ImGui::TableNextColumn();
-				ImGui::PushItemWidth(50.0f);
+				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptCorpse);
-				if (ImGui::SliderInt("Resize: Corpse(s)##inputCS", &AS_Config.SizeCorpse, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
+				if (ImGui::SliderInt("Resize: Corpse(s)", &AS_Config.SizeCorpse, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
 				{
 					if (AS_Config.OptAutoSave)
 					{
@@ -1157,13 +1161,12 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextColumn();
 				if (ImGui::Checkbox("##OptNPC", &AS_Config.OptNPC))
 				{
-					AS_Config.OptNPC = !AS_Config.OptNPC;
-					DoCommandf("/autosize npc");
+					DoCommandf("/autosize npc %s", AS_Config.OptNPC ? "on" : "off");
 				}
 				ImGui::TableNextColumn();
-				ImGui::PushItemWidth(50.0f);
+				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptNPC);
-				if (ImGui::SliderInt("Resize: NPC(s)##inputNS", &AS_Config.SizeNPC, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
+				if (ImGui::SliderInt("Resize: NPC(s)", &AS_Config.SizeNPC, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp))
 				{
 					if (AS_Config.OptAutoSave)
 					{
@@ -1174,9 +1177,24 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::EndTable();
 			}
 			
+			// display the button if autosave option is disabled
+			if (!AS_Config.OptAutoSave)
+			{
+				if (ImGui::Button("Reload INI"))
+				{
+					DoCommandf("/autosize load");
+				}
+			}
+
 			// display the button if any option is not enabled
 			if (!AS_Config.OptCorpse || !AS_Config.OptMerc || !AS_Config.OptMount || !AS_Config.OptNPC || !AS_Config.OptPC || !AS_Config.OptPet || !AS_Config.OptSelf)
 			{
+				// use the same line if Reload INI button is visible
+				if (!AS_Config.OptAutoSave)
+				{
+					ImGui::SameLine();
+				}
+				// this button will enable the options which are disabled
 				if (ImGui::Button("Resize Everything (select all)"))
 				{
 					DoCommandf("/autosize everything");
@@ -1185,18 +1203,11 @@ void DrawAutoSize_MQSettingsPanel()
 
 			ImGui::SeparatorText("Synchronize clients");
 			ImGui::BeginDisabled(loaded_dannet || loaded_eqbc);
-			if (ImGui::RadioButton("None", &selectedComms, static_cast<int>(CommunicationMode::None)))
-			{
-				selectedComms = static_cast<int>(CommunicationMode::None);
-				return;
-			}
+			ImGui::RadioButton("None", &selectedComms, static_cast<int>(eCommunicationMode::None));
 			ImGui::EndDisabled();
 
 			ImGui::BeginDisabled(!loaded_dannet);
-			if (ImGui::RadioButton("MQ2DanNet", &selectedComms, static_cast<int>(CommunicationMode::DanNet)))
-			{
-				selectedComms = static_cast<int>(CommunicationMode::DanNet);
-			}
+			ImGui::RadioButton("MQ2DanNet", &selectedComms, static_cast<int>(eCommunicationMode::DanNet));
 			if (!loaded_dannet)
 			{
 				ImGui::SameLine();
@@ -1205,10 +1216,7 @@ void DrawAutoSize_MQSettingsPanel()
 			ImGui::EndDisabled();
 			
 			ImGui::BeginDisabled(!loaded_eqbc);
-			if (ImGui::RadioButton("MQ2EQBC", &selectedComms, static_cast<int>(CommunicationMode::EQBC)))
-			{
-				selectedComms = static_cast<int>(CommunicationMode::EQBC);
-			}
+			ImGui::RadioButton("MQ2EQBC", &selectedComms, static_cast<int>(eCommunicationMode::EQBC));
 			if (!loaded_eqbc)
 			{
 				ImGui::SameLine();
@@ -1217,7 +1225,7 @@ void DrawAutoSize_MQSettingsPanel()
 			ImGui::EndDisabled();
 
 			// dannet
-			if (selectedComms == static_cast<int>(CommunicationMode::DanNet) && loaded_dannet)
+			if (selectedComms == static_cast<int>(eCommunicationMode::DanNet) && loaded_dannet)
 			{
 				if (ImGui::Button("All"))
 				{
@@ -1242,7 +1250,7 @@ void DrawAutoSize_MQSettingsPanel()
 					SendGroupCommand("group");
 				}
 				ImGui::EndDisabled();
-			} else if (selectedComms == static_cast<int>(CommunicationMode::EQBC) && loaded_eqbc)
+			} else if (selectedComms == static_cast<int>(eCommunicationMode::EQBC) && loaded_eqbc)
 			{
 				// eqbc
 				if (ImGui::Button("All"))
@@ -1367,9 +1375,9 @@ void DrawAutoSize_MQSettingsPanel()
 // send instruction to selected groups:
 // -> DanNet: all, zone, raid, group
 // -> EQBC: all, group
-void SendGroupCommand(const std::string& who)
+void SendGroupCommand(const std::string_view who)
 {
-	if (selectedComms == static_cast<int>(CommunicationMode::None))
+	if (selectedComms == static_cast<int>(eCommunicationMode::None))
 	{
 		WriteChatf("MQ2AutoSize: Cannot execute group command, no group plugin configured.");
 		return;
@@ -1443,7 +1451,7 @@ void SendGroupCommand(const std::string& who)
 	}
 
 	// instructions are sent to others, since we have the configuration already
-	if (selectedComms == static_cast<int>(CommunicationMode::DanNet))
+	if (selectedComms == static_cast<int>(eCommunicationMode::DanNet))
 	{
 		if (who == "zone")
 			groupCommand += fmt::format("/dgze {}", instruction);
@@ -1454,7 +1462,7 @@ void SendGroupCommand(const std::string& who)
 		else if (who == "all")
 			groupCommand += fmt::format("/dge {}", instruction);
 	}
-	else if (selectedComms == static_cast<int>(CommunicationMode::EQBC))
+	else if (selectedComms == static_cast<int>(eCommunicationMode::EQBC))
 	{
 		if (who == "group")
 			groupCommand += fmt::format("/bcg /{}", instruction);
@@ -1485,44 +1493,46 @@ void ChooseInstructionPlugin()
 	bool prev_loaded_eqbc = loaded_eqbc;
 	bool prev_loaded_dannet = loaded_dannet;
 
-	loaded_eqbc = GetPlugin("MQ2EQBC");
-	loaded_dannet = GetPlugin("MQ2Dannet");
+	loaded_eqbc = IsPluginLoaded("MQ2EQBC");
+	WriteChatf("DEBUG: EQBC = %d", loaded_eqbc);
+	loaded_dannet = IsPluginLoaded("MQ2DanNet");
+	WriteChatf("DEBUG: Dannet = %d", loaded_dannet);
 
 	if (loaded_dannet)
 	{
-		selectedComms = static_cast<int>(CommunicationMode::DanNet);
+		selectedComms = static_cast<int>(eCommunicationMode::DanNet);
 	}
 	else if (loaded_eqbc)
 	{
-		selectedComms = static_cast<int>(CommunicationMode::EQBC);
+		selectedComms = static_cast<int>(eCommunicationMode::EQBC);
 	}
 	else
 	{
-		selectedComms = static_cast<int>(CommunicationMode::None);
+		selectedComms = static_cast<int>(eCommunicationMode::None);
 	}
 
 	// check for changes in loaded plugins
-	if (prev_loaded_dannet && !loaded_dannet && loaded_eqbc)
+	if (!loaded_eqbc && !loaded_dannet)
 	{
-		selectedComms = static_cast<int>(CommunicationMode::EQBC);
+		selectedComms = static_cast<int>(eCommunicationMode::None);
+	}
+	else if (prev_loaded_dannet && !loaded_dannet && loaded_eqbc)
+	{
+		selectedComms = static_cast<int>(eCommunicationMode::EQBC);
 	}
 	else if (prev_loaded_eqbc && !loaded_eqbc && loaded_dannet)
 	{
-		selectedComms = static_cast<int>(CommunicationMode::DanNet);
+		selectedComms = static_cast<int>(eCommunicationMode::DanNet);
 	}
 	else if (!prev_loaded_eqbc && !prev_loaded_dannet)
 	{
 		if (loaded_eqbc && !loaded_dannet)
 		{
-			selectedComms = static_cast<int>(CommunicationMode::EQBC);
+			selectedComms = static_cast<int>(eCommunicationMode::EQBC);
 		}
 		else if (!loaded_eqbc && loaded_dannet)
 		{
-			selectedComms = static_cast<int>(CommunicationMode::DanNet);
-		}
-		else
-		{
-			selectedComms = static_cast<int>(CommunicationMode::None);
+			selectedComms = static_cast<int>(eCommunicationMode::DanNet);
 		}
 	}
 }
@@ -1539,14 +1549,14 @@ void ChooseInstructionPlugin()
  */
 // this function is used as a toggle between Zone and Range
 // params: zonewide or range
-void emulate(const std::string& type)
+void emulate(const std::string_view type)
 {
 	if (type == "zonewide")
 	{
 		if (AS_Config.ResizeRange != FAR_CLIP_PLANE)
 		{
 			previousRangeDistance = AS_Config.ResizeRange;
-			optZonewide = static_cast<int>(ResizeMode::Zonewide);
+			ResizeMode = static_cast<int>(eResizeMode::Zonewide);
 			AS_Config.ResizeRange = FAR_CLIP_PLANE;
 			WriteChatf("\ay%s\aw:: AutoSize (\ayRange\ax) now \ardisabled\ax!", mqplugin::PluginName);
 			WriteChatf("\ay%s\aw:: AutoSize (\ayZonewide\ax) now \agenabled\ax!", mqplugin::PluginName);
@@ -1559,7 +1569,7 @@ void emulate(const std::string& type)
 		if (AS_Config.ResizeRange == FAR_CLIP_PLANE)
 		{
 			AS_Config.ResizeRange = previousRangeDistance;
-			optZonewide = static_cast<int>(ResizeMode::Range);
+			ResizeMode = static_cast<int>(eResizeMode::Range);
 			WriteChatf("\ay%s\aw:: AutoSize (\ayZonewide\ax) now \ardisabled\ax!", mqplugin::PluginName);
 			WriteChatf("\ay%s\aw:: AutoSize (\ayRange\ax) now \agenabled\ax!", mqplugin::PluginName);
 			SpawnListResize(false);
@@ -1579,7 +1589,7 @@ int RoundToNearestTen(int value)
 	}
 	else if (value > MAX_SIZE)
 	{
-		return 250;
+		return MAX_SIZE;
 	}
 
 	int roundedValue = (value + 9) / 10 * 10;
@@ -1587,7 +1597,7 @@ int RoundToNearestTen(int value)
 	// clamp upper value post rounding
 	if (roundedValue > MAX_SIZE)
 	{
-		return 250;
+		return MAX_SIZE;
 	}
 	else
 	{
@@ -1598,25 +1608,11 @@ int RoundToNearestTen(int value)
 // check if we are in a group
 static bool isInGroup()
 {
-	if (pLocalPC)
-	{
-		if (pLocalPC->Group)
-		{
-			return true;
-		}
-	}
-	return false;
+	return pLocalPC && pLocalPC->Group;
 }
 
 // check if we are in a raid
 static bool isInRaid()
 {
-	if (pRaid)
-	{
-		if (pRaid->RaidMemberCount)
-		{
-			return true;
-		}
-	}
-	return false;
+	return pRaid && pRaid->RaidMemberCount;
 }

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -41,7 +41,7 @@ enum class eCommunicationMode
 
 	Default = None
 };
-int selectedComms = static_cast<int>(eCommunicationMode::Default);
+eCommunicationMode selectedComms;
 
 enum class eResizeMode
 {
@@ -1011,6 +1011,13 @@ void handle_plugin_change(std::string_view action, std::string_view pluginRef)
 	commsCheck = GetTickCount64() + 300; // 300ms delay
 }
 
+template <typename T>
+bool RadioButton(const char* label, T* value, T defaultValue)
+{
+	using UnderlyingType = std::underlying_type_t<T>;
+	return ImGui::RadioButton(label, reinterpret_cast<UnderlyingType*>(value), static_cast<UnderlyingType>(defaultValue));
+}
+
 void DrawAutoSize_MQSettingsPanel()
 {
 	ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "MQ2AutoSize");
@@ -1221,7 +1228,7 @@ void DrawAutoSize_MQSettingsPanel()
 			ImGui::SeparatorText("Synchronize clients");
 			ImGui::TextWrapped("This section provides the ability to broadcast your settings to connected peers based on which communication path exists.");
 			ImGui::BeginDisabled(loaded_dannet || loaded_eqbc);
-			ImGui::RadioButton("None", &selectedComms, static_cast<int>(eCommunicationMode::None));
+			RadioButton("None", &selectedComms, eCommunicationMode::None);
 			if (loaded_dannet || loaded_eqbc)
 			{
 				ImGui::SameLine();
@@ -1230,7 +1237,7 @@ void DrawAutoSize_MQSettingsPanel()
 			ImGui::EndDisabled();
 
 			ImGui::BeginDisabled(!loaded_dannet);
-			ImGui::RadioButton("MQ2DanNet", &selectedComms, static_cast<int>(eCommunicationMode::DanNet));
+			RadioButton("MQ2DanNet", &selectedComms, eCommunicationMode::DanNet);
 			if (!loaded_dannet)
 			{
 				ImGui::SameLine();
@@ -1239,7 +1246,7 @@ void DrawAutoSize_MQSettingsPanel()
 			ImGui::EndDisabled();
 
 			ImGui::BeginDisabled(!loaded_eqbc);
-			ImGui::RadioButton("MQ2EQBC", &selectedComms, static_cast<int>(eCommunicationMode::EQBC));
+			RadioButton("MQ2EQBC", &selectedComms, eCommunicationMode::EQBC);
 			if (!loaded_eqbc)
 			{
 				ImGui::SameLine();
@@ -1248,7 +1255,7 @@ void DrawAutoSize_MQSettingsPanel()
 			ImGui::EndDisabled();
 
 			// dannet
-			if (selectedComms == static_cast<int>(eCommunicationMode::DanNet) && loaded_dannet)
+			if (selectedComms == eCommunicationMode::DanNet && loaded_dannet)
 			{
 				if (ImGui::Button("All"))
 				{
@@ -1274,7 +1281,7 @@ void DrawAutoSize_MQSettingsPanel()
 				}
 				ImGui::EndDisabled();
 			}
-			else if (selectedComms == static_cast<int>(eCommunicationMode::EQBC) && loaded_eqbc)
+			else if (selectedComms == eCommunicationMode::EQBC && loaded_eqbc)
 			{
 				// eqbc
 				if (ImGui::Button("All"))
@@ -1402,7 +1409,7 @@ void DrawAutoSize_MQSettingsPanel()
 // -> EQBC: all, group
 void SendGroupCommand(const std::string_view who)
 {
-	if (selectedComms == static_cast<int>(eCommunicationMode::None))
+	if (selectedComms == eCommunicationMode::None)
 	{
 		WriteChatf("MQ2AutoSize: Cannot execute group command, no group plugin configured.");
 		return;
@@ -1476,7 +1483,7 @@ void SendGroupCommand(const std::string_view who)
 	}
 
 	// instructions are sent to others, since we have the configuration already
-	if (selectedComms == static_cast<int>(eCommunicationMode::DanNet))
+	if (selectedComms == eCommunicationMode::DanNet)
 	{
 		if (who == "zone")
 			groupCommand += fmt::format("/dgze {}", instruction);
@@ -1487,7 +1494,7 @@ void SendGroupCommand(const std::string_view who)
 		else if (who == "all")
 			groupCommand += fmt::format("/dge {}", instruction);
 	}
-	else if (selectedComms == static_cast<int>(eCommunicationMode::EQBC))
+	else if (selectedComms == eCommunicationMode::EQBC)
 	{
 		if (who == "group")
 			groupCommand += fmt::format("/bcg /{}", instruction);
@@ -1521,22 +1528,22 @@ void ChooseInstructionPlugin()
 	// prefer DanNet unless EQBC is currently selected
 	if (loaded_eqbc && loaded_dannet)
 	{
-		if (selectedComms != static_cast<int>(eCommunicationMode::EQBC))
+		if (selectedComms != eCommunicationMode::EQBC)
 		{
-			selectedComms = static_cast<int>(eCommunicationMode::DanNet);
+			selectedComms = eCommunicationMode::DanNet;
 		}
 	}
 	else if (loaded_dannet)
 	{
-		selectedComms = static_cast<int>(eCommunicationMode::DanNet);
+		selectedComms = eCommunicationMode::DanNet;
 	}
 	else if (loaded_eqbc)
 	{
-		selectedComms = static_cast<int>(eCommunicationMode::EQBC);
+		selectedComms = eCommunicationMode::EQBC;
 	}
 	else
 	{
-		selectedComms = static_cast<int>(eCommunicationMode::None);
+		selectedComms = eCommunicationMode::None;
 	}
 }
 

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -63,7 +63,7 @@ public:
 		OptPC = true;
 		OptNPC = OptPet = OptMerc = OptMount = OptCorpse = OptSelf = OptAutoSave = false;
 		ResizeRange = 50;
-		SizeDefault = SizePC = SizeNPC = SizePet = SizeMerc = SizeMount = SizeCorpse = SizeSelf = 1;
+		SizePC = SizeNPC = SizePet = SizeMerc = SizeMount = SizeCorpse = SizeSelf = 1;
 	};
 
 	bool OptAutoSave;
@@ -76,7 +76,6 @@ public:
 	bool OptSelf;
 
 	int ResizeRange;
-	int SizeDefault;
 	int SizePC;
 	int SizeNPC;
 	int SizePet;
@@ -102,7 +101,6 @@ public:
 		ResizeCorpse,
 		ResizeSelf,
 		Range,
-		SizeDefault,
 		SizePC,
 		SizeNPC,
 		SizePets,
@@ -123,7 +121,6 @@ public:
 		TypeMember(ResizeCorpse);
 		TypeMember(ResizeSelf);
 		TypeMember(Range);
-		TypeMember(SizeDefault);
 		TypeMember(SizePC);
 		TypeMember(SizeNPC);
 		TypeMember(SizePets);
@@ -180,10 +177,6 @@ public:
 				return true;
 			case Range:
 				Dest.Int = AS_Config.ResizeRange;
-				Dest.Type = datatypes::pIntType;
-				return true;
-			case SizeDefault:
-				Dest.Int = AS_Config.SizeDefault;
 				Dest.Type = datatypes::pIntType;
 				return true;
 			case SizePC:
@@ -292,7 +285,6 @@ void LoadINI() {
 	AS_Config.OptCorpse = getOptionValue("Config", "ResizeCorpse", "off");
 	AS_Config.OptSelf = getOptionValue("Config", "ResizeSelf", "off");
 	AS_Config.ResizeRange = getSaneSize("Config", "Range", AS_Config.ResizeRange);
-	AS_Config.SizeDefault = getSaneSize("Config", "SizeDefault", MIN_SIZE);
 	AS_Config.SizePC = getSaneSize("Config", "SizePC", MIN_SIZE);
 	AS_Config.SizeNPC = getSaneSize("Config", "SizeNPC", MIN_SIZE);
 	AS_Config.SizePet = getSaneSize("Config", "SizePets", MIN_SIZE);
@@ -321,7 +313,6 @@ void SaveINI() {
 	if (AS_Config.ResizeRange != FAR_CLIP_PLANE) {
 		WritePrivateProfileString("Config", "Range", std::to_string(AS_Config.ResizeRange), INIFileName);
 	}
-	WritePrivateProfileString("Config", "SizeDefault", std::to_string(AS_Config.SizeDefault), INIFileName);
 	WritePrivateProfileString("Config", "SizePC", std::to_string(AS_Config.SizePC), INIFileName);
 	WritePrivateProfileString("Config", "SizeNPC", std::to_string(AS_Config.SizeNPC), INIFileName);
 	WritePrivateProfileString("Config", "SizePets", std::to_string(AS_Config.SizePet), INIFileName);
@@ -602,8 +593,6 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 		return;
 	}
 	else if (ci_equals(szCurArg, "size")) {
-		// deprecated because having a default size to be applied to things which are not opt'd to be resized makes no sense.
-		//SetSizeConfig("Default", iNewSize, &AS_Config.SizeDefault);
 		WriteChatf("\ay%s\aw:: This feature (\ay%s\ax) has been deprecated. Check /mqsetting -> plugins -> AutoSize.", MODULE_NAME, szCurArg);
 	}
 	else if (ci_equals(szCurArg, "sizepc")) {

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -322,8 +322,9 @@ void SaveINI(const std::string& param = "", const bool squelch = 0) {
 		if (it != configMap.end()) {
 			WritePrivateProfileString("Config", it->first, it->second, INIFileName);
 		}
-		// special handling for Range key, we don't want to write the FAR_CLIP_PLANE to disk
-		else if (param == "ResizeRange" && AS_Config.ResizeRange != FAR_CLIP_PLANE) {
+		// special handling for Range key, we don't want to write the value to disk unless
+		// it's between MIN_SIZE and MAX_SIZE
+		else if (param == "Range" && AS_Config.ResizeRange >= MIN_SIZE && AS_Config.ResizeRange <= MAX_SIZE) {
 			WritePrivateProfileString("Config", "Range", std::to_string(AS_Config.ResizeRange), INIFileName);
 		}
 	}
@@ -333,7 +334,7 @@ void SaveINI(const std::string& param = "", const bool squelch = 0) {
 			WritePrivateProfileString("Config", key, value, INIFileName);
 		}
 		// special handling for Range since it's not part of the map (intentionally)
-		if (AS_Config.ResizeRange != FAR_CLIP_PLANE) {
+		if (AS_Config.ResizeRange >= MIN_SIZE && AS_Config.ResizeRange <= MAX_SIZE) {
 			WritePrivateProfileString("Config", "Range", std::to_string(AS_Config.ResizeRange), INIFileName);
 		}
 	}
@@ -866,7 +867,7 @@ void DrawAutoSize_MQSettingsPanel() {
 				if (ImGui::SliderInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 10, 250, "%d", ImGuiSliderFlags_NoInput|ImGuiSliderFlags_AlwaysClamp)) {
 					AS_Config.ResizeRange = RoundToNearestTen(AS_Config.ResizeRange);
 					if (AS_Config.OptAutoSave) {
-						SaveINI("ResizeRange", true);
+						SaveINI("Range", true);
 					}
 				}
 				ImGui::EndDisabled();

--- a/MQ2AutoSize.rc
+++ b/MQ2AutoSize.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0
- PRODUCTVERSION 1,0
+ FILEVERSION 1,1
+ PRODUCTVERSION 1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -73,11 +73,11 @@ BEGIN
 #else
             VALUE "FileDescription", "MQ2AutoSize Release Version"
 #endif
-            VALUE "FileVersion", "1.0"
+            VALUE "FileVersion", "1.1"
             VALUE "InternalName", "MQ2AutoSize.dll"
             VALUE "OriginalFilename", "MQ2AutoSize.dll"
             VALUE "ProductName", "MQ2AutoSize"
-            VALUE "ProductVersion", "1.0"
+            VALUE "ProductVersion", "1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # MQ2AutoSize
+
+Usage:
+   This plugin will automatically resize configured spawn groups to the specified
+   size. You can configure it to only resize within a specific range and then
+   resize back to normal when your distance moves out of that range.
+   Current default range is set to 50 and may be changed via UI panel, INI or cmd line
+
+   NOTE: These effects are client side only.
+
+Toggles (you may also append on or off to set):
+   /autosize autosave   - Automatically save settings to INI file when an option is toggled or size is set
+   /autosize            - Toggles AutoSize on/off with a range of 1000
+   /autosize dist       - Toggles distance-based AutoSize on/off
+   /autosize pc         - Toggles AutoSize PC spawn types
+   /autosize npc        - Toggles AutoSize NPC spawn types
+   /autosize pets       - Toggles AutoSize pet spawn types
+   /autosize mercs      - Toggles AutoSize mercenary spawn types
+   /autosize mounts     - Toggles AutoSize mounted player spawn types
+   /autosize corpse     - Toggles AutoSize corpse spawn types
+   /autosize everything - Toggles AutoSize all spawn types
+   /autosize self       - Toggles AutoSize for your character
+   /autosize range #    - Sets range for distance-based AutoSize
+
+(Valid sizes 1 to 250)
+   /autosize sizeself #   - Sets size for your character
+   /autosize sizepc #     - Sets size for PC spawn types
+   /autosize sizenpc #    - Sets size for NPC spawn types
+   /autosize sizepets #   - Sets size for pet spawn types
+   /autosize sizemercs #  - Sets size for mercenary spawn types
+   /autosize sizemounts # - Sets size for mounted player spawn types
+   /autosize sizecorpse # - Sets size for corpse spawn types
+
+Commands:
+   /autosize status - Display current plugin settings to chatwnd
+   /autosize help   - Display command syntax to chatwnd
+   /autosize save   - Save settings to INI file (auto on plugin unload)
+   /autosize load   - Load settings from INI file (auto on plugin load)


### PR DESCRIPTION
Added
- MQ Settings panel (/mqsettings -> plugin -> AutoSize)
- AutoSize TLO (check wiki for details)
- Introduced Synchronization ability - only available in the UI
- Enhanced options to accept instruction such as on and off, not just be a toggle. This was done to enable keeping toons in sync by setting values instead of randomly toggling.

Updated / Fixed
- Zonewide now uses 1000 range
- /autosize range # now works
- Reduced organic growth of code and made all toggle options use the ToggleOption function
- Fixed and altered how "Everything" works. Now it will enable the options, which work as intended.

Deprecated
- OptZone since it never worked as expected, replaced with Range of 1000 which is about the same as the EQ visible max clipping plane
- ResizeAll configuration, while Everything is still able to be enabled
- DefaultSize configuration and command (/autosize size), while Everything is still able to be enabled
- SizeDefault since having a default setting to resize something to, which wasn't opted in for resizing, doesn't actually make any sense. Outputs have persisted to ensure no script that scrapes the line breaks.
- SizeTarget (and /autosize target) since it would only resize for one frame if the type was managed by an Option for resizing
- OptByRange and SizeByRange, since the plugin now only uses range to resize


Under the hood
- Changed the majority of floats to integer as there was no reason for using all the floats
- Updated pCharSpawn to pLocalPlayer references