### PR TITLE
AutoSize soft switch to disable functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+7/26/2024
+--
+Added
+- UI and command to toggle the AutoSize functionality (`/autosize [on|off]`)
+- new TLO member: Enabled (`${AutoSize.Enabled}` or `mq.TLO.AutoSize.Enabled()`)
+
+Updated
+- Wording for `/autosize` and `/autosize dist [on|off]` to better explain how to use them
+
 7/11/2024
 --
 Added

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -357,15 +357,13 @@ void ChangeSize(PlayerClient* pChangeSpawn, float fNewSize)
 }
 
 
-void HandleResize(PlayerClient* pSpawn, bool bReset, int size, bool option) {
-	if (option) {
-		// only resize if functionality is enabled
-		if (AS_Config.Enabled) {
-			ChangeSize(pSpawn, bReset ? ZERO_SIZE : size);
-		}
-		else {
-			ChangeSize(pSpawn, ZERO_SIZE);
-		}
+void HandleResize(PlayerClient* pSpawn, bool bReset, int size) {
+	// only resize if functionality is enabled
+	if (AS_Config.Enabled) {
+		ChangeSize(pSpawn, bReset ? ZERO_SIZE : size);
+	}
+	else {
+		ChangeSize(pSpawn, ZERO_SIZE);
 	}
 }
 
@@ -382,7 +380,7 @@ void SizePasser(PlayerClient* pSpawn, bool bReset)
 	{
 		if (AS_Config.OptSelf)
 		{
-			HandleResize(pSpawn, bReset, AS_Config.SizeSelf, AS_Config.OptSelf);
+			HandleResize(pSpawn, bReset, AS_Config.SizeSelf);
 		}
 			
 		return;
@@ -393,37 +391,37 @@ void SizePasser(PlayerClient* pSpawn, bool bReset)
 	case PC:
 		if (AS_Config.OptPC)
 		{
-			HandleResize(pSpawn, bReset, AS_Config.SizePC, AS_Config.OptPC);
+			HandleResize(pSpawn, bReset, AS_Config.SizePC);
 		}
 		break;
 	case NPC:
 		if (AS_Config.OptNPC)
 		{
-			HandleResize(pSpawn, bReset, AS_Config.SizeNPC, AS_Config.OptNPC);	
+			HandleResize(pSpawn, bReset, AS_Config.SizeNPC);	
 		}
 		break;
 	case PET:
 		if (AS_Config.OptPet)
 		{
-			HandleResize(pSpawn, bReset, AS_Config.SizePet, AS_Config.OptPet);
+			HandleResize(pSpawn, bReset, AS_Config.SizePet);
 		}
 		break;
 	case MERCENARY:
 		if (AS_Config.OptMerc)
 		{
-			HandleResize(pSpawn, bReset, AS_Config.SizeMerc, AS_Config.OptMerc);
+			HandleResize(pSpawn, bReset, AS_Config.SizeMerc);
 		}
 		break;
 	case MOUNT:
 		if (AS_Config.OptMount && pSpawn->SpawnID != pLocalPlayer->SpawnID)
 		{
-			HandleResize(pSpawn, bReset, AS_Config.SizeMount, AS_Config.OptMount);
+			HandleResize(pSpawn, bReset, AS_Config.SizeMount);
 		}
 		break;
 	case CORPSE:
 		if (AS_Config.OptCorpse)
 		{
-			HandleResize(pSpawn, bReset, AS_Config.SizeCorpse, AS_Config.OptCorpse);
+			HandleResize(pSpawn, bReset, AS_Config.SizeCorpse);
 		}
 		break;
 	default:

--- a/MQ2AutoSize.rc
+++ b/MQ2AutoSize.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,1
- PRODUCTVERSION 1,1
+ FILEVERSION 1,2
+ PRODUCTVERSION 1,2
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -73,11 +73,11 @@ BEGIN
 #else
             VALUE "FileDescription", "MQ2AutoSize Release Version"
 #endif
-            VALUE "FileVersion", "1.1"
+            VALUE "FileVersion", "1.2"
             VALUE "InternalName", "MQ2AutoSize.dll"
             VALUE "OriginalFilename", "MQ2AutoSize.dll"
             VALUE "ProductName", "MQ2AutoSize"
-            VALUE "ProductVersion", "1.1"
+            VALUE "ProductVersion", "1.2"
         END
     END
     BLOCK "VarFileInfo"

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ NOTE: These effects are client side only.
 ## Toggles (you may also append on or off to set the value):
 
 * /autosize autosave   - Automatically save settings to INI file when an option is toggled or size is set
-* /autosize            - Toggles AutoSize on/off with a range of 1000
-* /autosize dist       - Toggles distance-based AutoSize on/off
-* /autosize pc         - Toggles AutoSize PC spawn types
-* /autosize npc        - Toggles AutoSize NPC spawn types
-* /autosize pets       - Toggles AutoSize pet spawn types
-* /autosize mercs      - Toggles AutoSize mercenary spawn types
-* /autosize mounts     - Toggles AutoSize mounted player spawn types
-* /autosize corpse     - Toggles AutoSize corpse spawn types
-* /autosize everything - Toggles AutoSize all spawn types
-* /autosize self       - Toggles AutoSize for your character
-* /autosize range #    - Sets range for distance-based AutoSize
+* /autosize            - Toggles AutoSize functionality (on/off)
+* /autosize dist       - Toggles distance-based vs Zonewide (range 1000)
+* /autosize pc         - Toggles AutoSize PC spawn types (on/off)
+* /autosize npc        - Toggles AutoSize NPC spawn types (on/off)
+* /autosize pets       - Toggles AutoSize pet spawn types (on/off)
+* /autosize mercs      - Toggles AutoSize mercenary spawn types (on/off)
+* /autosize mounts     - Toggles AutoSize mounted player spawn types (on/off)
+* /autosize corpse     - Toggles AutoSize corpse spawn types (on/off)
+* /autosize everything - Toggles AutoSize all spawn types (on/off)
+* /autosize self       - Toggles AutoSize for your character (on/off)
 
 ## Size configuration (valid sizes 1 to 250)
+* /autosize range #      - Sets range for distance-based AutoSize
 * /autosize sizeself #   - Sets size for your character
 * /autosize sizepc #     - Sets size for PC spawn types
 * /autosize sizenpc #    - Sets size for NPC spawn types


### PR DESCRIPTION
Added
- UI and command to toggle the AutoSize functionality (`/autosize [on|off]`)
- new TLO member: Enabled (`${AutoSize.Enabled}` or `mq.TLO.AutoSize.Enabled()`)

Updated
- Wording for `/autosize` and `/autosize dist [on|off]` to better explain how to use them
