### PR TITLE
Adding command for quick access to UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+8/09/2024
+--
+Added
+- command to open UI: /autosize [gui | ui | show]
+
 7/26/2024
 --
 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-8/09/2024
+8/12/2024
 --
 Added
-- command to open UI: /autosize [gui | ui | show]
+- command to open UI: /autosize [gui|ui]
+
+Fixed
+- Zonewide value (range = 1000) will now be saved to INI like all other values
 
 7/26/2024
 --

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -621,6 +621,10 @@ void AutoSizeCmd(PlayerClient*, const char* szLine)
 		// toggle AutoSize functionality via configuration
 		ToggleOption("AutoSize functionality", &AS_Config.Enabled);
 	}
+	else if (ci_equals(szCurArg, "gui") || ci_equals(szCurArg, "show") || ci_equals(szCurArg, "ui"))
+	{
+		DoCommand("/mqsettings plugins/autosize");
+	}
 	else if (ci_equals(szCurArg, "on"))
 	{
 		SetOption("AutoSize functionality", &AS_Config.Enabled, true);

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1355,7 +1355,7 @@ void DrawAutoSize_MQSettingsPanel()
 			{
 				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 150.0f);
 				ImGui::TableSetupColumn("");
-				ImGui::TableNextColumn(); ImGui::Text("/autosize [gui | ui | show]");
+				ImGui::TableNextColumn(); ImGui::Text("/autosize [gui | ui]");
 				ImGui::TableNextColumn(); ImGui::Text("Display the ImGui panel under /mqsettings");
 				ImGui::TableNextRow();
 				ImGui::TableNextColumn(); ImGui::Text("/autosize status");

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -5,7 +5,7 @@
 
 // Plugin Setup
 PreSetup("MQ2AutoSize");
-PLUGIN_VERSION(1.2);
+PLUGIN_VERSION(1.3);
 
 // Constants
 constexpr std::chrono::milliseconds UPDATE_INTERVAL{ 200 }; // Controls the update frequency to perform a radius-based resize
@@ -508,7 +508,7 @@ void OutputHelp()
 	WriteChatf("--- Valid Size Syntax (%d to %d) ---", MIN_SIZE, MAX_SIZE);
 	WriteChatf("  \ag/autosize\ax [ \aysizepc\ax | \aysizenpc\ax | \aysizepets\ax | \aysizemercs\ax | \aysizemounts\ax | \aysizecorpse\ax | \aysizeself\ax ] [ \ay#\ax ]");
 	WriteChatf("--- Other Valid Commands ---");
-	WriteChatf("  \ag/autosize\ax [ \ayhelp\ax | \aystatus\ax | \ayautosave\ax | \aysave\ax | \ayload\ax ]");
+	WriteChatf("  \ag/autosize\ax [ \ayhelp\ax | \aygui\ax | \ayui\ax | \ayshow\ax | \aystatus\ax | \ayautosave\ax | \aysave\ax | \ayload\ax ]");
 	WriteChatf("--- Ability to set options ---");
 	WriteChatf("  \ag/autosize\ax [ \ayautosize\ax | \aypc\ax | \aynpc\ax | \aypets\ax | \aymercs\ax | \aymounts\ax | \aycorpse\ax | \ayeverything\ax | \ayself\ax ] [\agon\ax | \aroff\ax]");
 }
@@ -1352,6 +1352,9 @@ void DrawAutoSize_MQSettingsPanel()
 			{
 				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 150.0f);
 				ImGui::TableSetupColumn("");
+				ImGui::TableNextColumn(); ImGui::Text("/autosize [gui | ui | show]");
+				ImGui::TableNextColumn(); ImGui::Text("Display the ImGui panel under /mqsettings");
+				ImGui::TableNextRow();
 				ImGui::TableNextColumn(); ImGui::Text("/autosize status");
 				ImGui::TableNextColumn(); ImGui::Text("Display current plugin settings to chatwnd");
 				ImGui::TableNextRow();

--- a/MQ2AutoSize.rc
+++ b/MQ2AutoSize.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,2
- PRODUCTVERSION 1,2
+ FILEVERSION 1,3
+ PRODUCTVERSION 1,3
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -73,11 +73,11 @@ BEGIN
 #else
             VALUE "FileDescription", "MQ2AutoSize Release Version"
 #endif
-            VALUE "FileVersion", "1.2"
+            VALUE "FileVersion", "1.3"
             VALUE "InternalName", "MQ2AutoSize.dll"
             VALUE "OriginalFilename", "MQ2AutoSize.dll"
             VALUE "ProductName", "MQ2AutoSize"
-            VALUE "ProductVersion", "1.2"
+            VALUE "ProductVersion", "1.3"
         END
     END
     BLOCK "VarFileInfo"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ NOTE: These effects are client side only.
 
 ## Other Commands:
 * /autosize status - Display current plugin settings to MQ Console and or chatwnd if loaded
+* /autosize [gui | ui | show] - Display the ImGui panel under /mqsettings
 * /autosize help   - Display command syntax to MQ Console and or chatwnd if loaded
 * /autosize save   - Save settings to INI file (auto on plugin unload)
 * /autosize load   - Load settings from INI file (auto on plugin load)


### PR DESCRIPTION
This PR contains 2 additions:

- introduced `/autosize [ gui | ui ]` to get to the ImGui panel within `/mqsettings`
- enabled the saving of Zonewide (range 1000) to INI